### PR TITLE
Fix execute_card parameter encoding for Metabase API

### DIFF
--- a/dist/handlers/card-tools.js
+++ b/dist/handlers/card-tools.js
@@ -114,7 +114,8 @@ export class CardToolHandlers {
                         },
                         parameters: {
                             type: "object",
-                            description: "Optional parameters for the query",
+                            description: 'Optional parameters for the query. Pass as key-value pairs where keys match template tag names (e.g., { "date_filter": "2025-01-01" })',
+                            additionalProperties: true,
                         },
                     },
                     required: ["card_id"],

--- a/src/client/metabase-client.ts
+++ b/src/client/metabase-client.ts
@@ -16,6 +16,7 @@ import {
   Field,
   PermissionGroup,
   QueryResult,
+  MetabaseQueryParameter,
 } from "../types/metabase.js";
 
 export class MetabaseClient {
@@ -191,11 +192,46 @@ export class MetabaseClient {
     }
   }
 
+  /**
+   * Transform user-friendly key-value parameters into Metabase's array format
+   */
+  private transformParameters(
+    params: Record<string, any>
+  ): MetabaseQueryParameter[] {
+    if (!params || Object.keys(params).length === 0) {
+      return [];
+    }
+    if (Array.isArray(params)) {
+      return params; // Already in correct format
+    }
+    return Object.entries(params).map(([key, value]) => ({
+      type: "category",
+      target: ["variable", ["template-tag", key]] as [
+        "variable",
+        ["template-tag", string],
+      ],
+      value: value,
+    }));
+  }
+
   async executeCard(id: number, parameters: any = {}): Promise<QueryResult> {
     await this.ensureAuthenticated();
-    const response = await this.axiosInstance.post(`/api/card/${id}/query`, {
-      parameters,
-    });
+
+    const transformedParams = this.transformParameters(parameters);
+    const body =
+      transformedParams.length > 0
+        ? `parameters=${encodeURIComponent(JSON.stringify(transformedParams))}`
+        : "";
+
+    const response = await this.axiosInstance.post(
+      `/api/card/${id}/query`,
+      body,
+      {
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+      }
+    );
     return response.data;
   }
 

--- a/src/handlers/card-tools.ts
+++ b/src/handlers/card-tools.ts
@@ -118,7 +118,9 @@ export class CardToolHandlers {
             },
             parameters: {
               type: "object",
-              description: "Optional parameters for the query",
+              description:
+                'Optional parameters for the query. Pass as key-value pairs where keys match template tag names (e.g., { "date_filter": "2025-01-01" })',
+              additionalProperties: true,
             },
           },
           required: ["card_id"],

--- a/src/types/metabase.ts
+++ b/src/types/metabase.ts
@@ -99,3 +99,9 @@ export interface QueryResult {
   row_count?: number;
   running_time?: number;
 }
+
+export interface MetabaseQueryParameter {
+  type: string;
+  target: ["variable", ["template-tag", string]];
+  value: string | number | boolean | string[];
+}


### PR DESCRIPTION

I'm a bit surprised this wasn't working - but maybe nobody ever executed a card ... ? 

The executeCard method was incorrectly sending parameters to Metabase's

/api/card/{id}/query endpoint. This fix:

- Changes Content-Type from application/json to application/x-www-form-urlencoded
- Transforms user-friendly key-value parameters into Metabase's expected array format
- Adds MetabaseQueryParameter type for proper typing
- Updates tool schema description to clarify expected input format
- Supports both simple key-value input and pre-formatted array input for backward compatibility



