### PR TITLE
fix: execute_card parameters should be array, not object

### DIFF
--- a/src/client/metabase-client.ts
+++ b/src/client/metabase-client.ts
@@ -191,11 +191,11 @@ export class MetabaseClient {
     }
   }
 
-  async executeCard(id: number, parameters: any = {}): Promise<QueryResult> {
+  async executeCard(id: number, parameters: any = []): Promise<QueryResult> {
     await this.ensureAuthenticated();
     const response = await this.axiosInstance.post(`/api/card/${id}/query`, {
-      parameters,
-    });
+    parameters: Array.isArray(parameters) ? parameters : [],
+  });
     return response.data;
   }
 

--- a/src/handlers/card-tools.ts
+++ b/src/handlers/card-tools.ts
@@ -248,7 +248,7 @@ export class CardToolHandlers {
   }
 
   private async executeCard(args: any): Promise<any> {
-    const { card_id, parameters = {} } = args;
+    const { card_id, parameters = [] } = args;
 
     if (!card_id) {
       throw new McpError(ErrorCode.InvalidParams, "Card ID is required");


### PR DESCRIPTION
The Metabase API endpoint POST /api/card/:id/query requires `parameters`
to be a sequential (array) type. Currently the default value is `{}` (object),
which causes Metabase to throw:

  Assert failed: (u/maybe? sequential? parameters)

Fix: change default from `{}` to `[]` in both metabase-client.ts and card-tools.ts,
and add an Array.isArray guard when passing the value to the API.

Tested against Metabase v0.51.1.