### PR TITLE
feat: smart parameter resolution for execute_card

### DIFF
--- a/src/handlers/card-tools.ts
+++ b/src/handlers/card-tools.ts
@@ -108,7 +108,14 @@ export class CardToolHandlers {
       },
       {
         name: "execute_card",
-        description: "Execute a Metabase question/card and get results",
+        description:
+          "Execute a Metabase question/card and get results. " +
+          "Parameters can be passed in two ways: " +
+          "(1) Simplified format - an object mapping parameter names to values, e.g. " +
+          '{"site_name": "guangzhou", "module_lv1": "L4"}. The tool will automatically ' +
+          "resolve the correct Metabase parameter format by inspecting the card's template tags. " +
+          "(2) Native Metabase format - an array of parameter objects with type/target/value fields. " +
+          "The simplified format is recommended as it handles text, date, and dimension parameters automatically.",
         inputSchema: {
           type: "object",
           properties: {
@@ -117,8 +124,9 @@ export class CardToolHandlers {
               description: "ID of the card/question to execute",
             },
             parameters: {
-              type: "object",
-              description: "Optional parameters for the query",
+              description:
+                "Query parameters. Either a simplified {name: value} object " +
+                "(recommended) or a native Metabase parameter array.",
             },
           },
           required: ["card_id"],
@@ -248,13 +256,31 @@ export class CardToolHandlers {
   }
 
   private async executeCard(args: any): Promise<any> {
-    const { card_id, parameters = [] } = args;
+    const { card_id, parameters } = args;
 
     if (!card_id) {
       throw new McpError(ErrorCode.InvalidParams, "Card ID is required");
     }
 
-    const result = await this.client.executeCard(card_id, parameters);
+    let resolvedParameters: any[] = [];
+
+    if (parameters !== undefined && parameters !== null) {
+      if (Array.isArray(parameters)) {
+        // Native Metabase format: pass through as-is
+        resolvedParameters = parameters;
+      } else if (
+        typeof parameters === "object" &&
+        Object.keys(parameters).length > 0
+      ) {
+        // Simplified format: resolve by inspecting card template tags
+        resolvedParameters = await this.resolveSimplifiedParameters(
+          card_id,
+          parameters
+        );
+      }
+    }
+
+    const result = await this.client.executeCard(card_id, resolvedParameters);
     return {
       content: [
         {
@@ -263,5 +289,77 @@ export class CardToolHandlers {
         },
       ],
     };
+  }
+
+  /**
+   * Resolve simplified {name: value} parameters to native Metabase format
+   * by inspecting the card's template tags.
+   *
+   * Template tag types and their corresponding parameter formats:
+   * - text: {type: "category", target: ["variable", ["template-tag", name]], value: [value]}
+   * - date: {type: "date/single", target: ["variable", ["template-tag", name]], value: value}
+   * - dimension: {type: "string/=", target: ["dimension", ["template-tag", name]], value: [value]}
+   * - number: {type: "number/=", target: ["variable", ["template-tag", name]], value: [value]}
+   */
+  private async resolveSimplifiedParameters(
+    cardId: number,
+    simplifiedParams: Record<string, any>
+  ): Promise<any[]> {
+    // Fetch card metadata to get template tag definitions
+    const card = await this.client.getCard(cardId);
+    const templateTags =
+      card?.dataset_query?.native?.["template-tags"] ||
+      card?.dataset_query?.native?.template_tags ||
+      {};
+
+    const resolvedParams: any[] = [];
+
+    for (const [name, value] of Object.entries(simplifiedParams)) {
+      const tag = templateTags[name];
+
+      if (!tag) {
+        // Unknown parameter: try as a generic category parameter
+        resolvedParams.push({
+          type: "category",
+          target: ["variable", ["template-tag", name]],
+          value: Array.isArray(value) ? value : [value],
+        });
+        continue;
+      }
+
+      const tagType = tag.type;
+
+      if (tagType === "dimension") {
+        // Dimension parameters link to a specific field
+        resolvedParams.push({
+          type: "string/=",
+          target: ["dimension", ["template-tag", name]],
+          value: Array.isArray(value) ? value : [value],
+        });
+      } else if (tagType === "date") {
+        // Date parameters
+        resolvedParams.push({
+          type: "date/single",
+          target: ["variable", ["template-tag", name]],
+          value: Array.isArray(value) ? value[0] : value,
+        });
+      } else if (tagType === "number") {
+        // Number parameters
+        resolvedParams.push({
+          type: "number/=",
+          target: ["variable", ["template-tag", name]],
+          value: Array.isArray(value) ? value : [value],
+        });
+      } else {
+        // text and other types
+        resolvedParams.push({
+          type: "category",
+          target: ["variable", ["template-tag", name]],
+          value: Array.isArray(value) ? value : [value],
+        });
+      }
+    }
+
+    return resolvedParams;
   }
 }


### PR DESCRIPTION
## Summary

This PR adds automatic parameter format resolution for the `execute_card` tool, making it significantly easier to pass query parameters — especially `dimension`-type parameters.

## Problem

Currently, users must construct the full native Metabase parameter array manually to filter card results. This is especially painful for `dimension`-type parameters which require a specific format:

```json
{
  "type": "string/=",
  "target": ["dimension", ["template-tag", "module_lv1"]],
  "value": ["L4"]
}
```

Most MCP clients (AI agents) don't know this format and end up passing parameters incorrectly, resulting in unfiltered results.

## Solution

The `execute_card` tool now accepts two parameter formats:

### 1. Simplified format (new, recommended)
Pass a plain `{name: value}` object:
```json
{
  "card_id": 28342,
  "parameters": {
    "site_name": "guangzhou",
    "module_lv1": "L4",
    "module_lv2": "XDriving"
  }
}
```

The tool automatically:
1. Fetches the card's metadata to inspect template tags
2. Determines each parameter's type (text, date, dimension, number)
3. Constructs the correct native Metabase parameter format

### 2. Native array format (existing, preserved)
The original array format continues to work for backwards compatibility:
```json
{
  "card_id": 28342,
  "parameters": [
    {"type": "string/=", "target": ["dimension", ["template-tag", "module_lv1"]], "value": ["L4"]}
  ]
}
```

## Parameter type mapping

| Template tag type | Generated parameter format |
|---|---|
| `text` | `{type: "category", target: ["variable", ...], value: [...]}` |
| `date` | `{type: "date/single", target: ["variable", ...], value: "..."}` |
| `dimension` | `{type: "string/=", target: ["dimension", ...], value: [...]}` |
| `number` | `{type: "number/=", target: ["variable", ...], value: [...]}` |

## Testing

Tested against a real Metabase instance with a card containing all parameter types (text, date, dimension):
- ✅ Simplified `{name: value}` format — correctly filters dimension parameters
- ✅ Native array format — backwards compatible
- ✅ No parameters — returns unfiltered results

## Changes

- `src/handlers/card-tools.ts`: Enhanced `execute_card` schema and added `resolveSimplifiedParameters()` method