### PR TITLE
fix: cascade-archive bug in PUT /api/dashboard/:id/cards fallback

### DIFF
--- a/src/handlers/dashboard-tools.ts
+++ b/src/handlers/dashboard-tools.ts
@@ -420,7 +420,7 @@ export class DashboardToolHandlers {
         result = await this.client.apiCall(
           "PUT",
           `/api/dashboard/${dashboard_id}/cards`,
-          { cards: updatedCards }
+          { dashcards: updatedCards, tabs: dashboard.tabs || [] }
         );
       } catch (putError) {
         // Approach 3: Try alternative endpoint structure
@@ -478,14 +478,14 @@ export class DashboardToolHandlers {
       } catch (altError) {
         // Approach 3: Update dashboard without the card
         const dashboard = await this.client.getDashboard(dashboard_id);
-        const updatedCards = (dashboard.cards || []).filter(
+        const updatedCards = (dashboard.dashcards || []).filter(
           (card: any) => card.id !== dashcard_id
         );
-        
+
         await this.client.apiCall(
           "PUT",
           `/api/dashboard/${dashboard_id}/cards`,
-          { cards: updatedCards }
+          { dashcards: updatedCards, tabs: dashboard.tabs || [] }
         );
       }
     }
@@ -537,17 +537,17 @@ export class DashboardToolHandlers {
       } catch (altError) {
         // Approach 3: Update entire dashboard cards array
         const dashboard = await this.client.getDashboard(dashboard_id);
-        const updatedCards = (dashboard.cards || []).map((card: any) => {
+        const updatedCards = (dashboard.dashcards || []).map((card: any) => {
           if (card.id === dashcard_id) {
             return { ...card, ...updateFields };
           }
           return card;
         });
-        
+
         result = await this.client.apiCall(
           "PUT",
           `/api/dashboard/${dashboard_id}/cards`,
-          { cards: updatedCards }
+          { dashcards: updatedCards, tabs: dashboard.tabs || [] }
         );
       }
     }

--- a/src/handlers/dashboard-tools.ts
+++ b/src/handlers/dashboard-tools.ts
@@ -69,6 +69,12 @@ export class DashboardToolHandlers {
               type: "boolean",
               description: "Set to true to archive the dashboard",
             },
+            tabs: {
+              type: "array",
+              description:
+                "Dashboard tabs. Array of { id, name, position } objects. For new tabs use negative id (-1, -2, ...). Server assigns real ids on save. When this field is provided, routed via PUT /api/dashboard/:id/cards bulk endpoint to preserve existing cards.",
+              items: { type: "object" },
+            },
           },
           required: ["dashboard_id"],
         },
@@ -150,6 +156,11 @@ export class DashboardToolHandlers {
               type: "object",
               description: "Visualization settings for the card on this dashboard",
             },
+            dashboard_tab_id: {
+              type: "number",
+              description:
+                "ID of the dashboard tab to place this card on. Omit for dashboards without tabs.",
+            },
           },
           required: ["dashboard_id", "card_id"],
         },
@@ -210,6 +221,11 @@ export class DashboardToolHandlers {
             visualization_settings: {
               type: "object",
               description: "Updated visualization settings",
+            },
+            dashboard_tab_id: {
+              type: "number",
+              description:
+                "Move this card to the specified dashboard tab. Omit to leave tab unchanged.",
             },
           },
           required: ["dashboard_id", "dashcard_id"],
@@ -324,23 +340,42 @@ export class DashboardToolHandlers {
   }
 
   private async updateDashboard(args: any): Promise<any> {
-    const { dashboard_id, ...updateFields } = args;
+    const { dashboard_id, tabs, ...updateFields } = args;
 
     if (!dashboard_id) {
       throw new McpError(ErrorCode.InvalidParams, "Dashboard ID is required");
     }
 
-    if (Object.keys(updateFields).length === 0) {
+    if (Object.keys(updateFields).length === 0 && tabs === undefined) {
       throw new McpError(
         ErrorCode.InvalidParams,
         "No fields provided for update"
       );
     }
 
-    const dashboard = await this.client.updateDashboard(
-      dashboard_id,
-      updateFields
-    );
+    let dashboard: any;
+
+    // Metadata fields (name/description/collection_id/parameters/archived)
+    // go through PUT /api/dashboard/:id as usual.
+    if (Object.keys(updateFields).length > 0) {
+      dashboard = await this.client.updateDashboard(dashboard_id, updateFields);
+    }
+
+    // `tabs` is not accepted by PUT /api/dashboard/:id. It must go through
+    // the bulk PUT /api/dashboard/:id/cards endpoint which takes
+    // `{ cards: [...], tabs: [...] }`. Preserve existing cards.
+    if (tabs !== undefined) {
+      const current = await this.client.getDashboard(dashboard_id);
+      const existingCards = (current.dashcards || []).map((c: any) =>
+        this.toDashcardPayload(c)
+      );
+      dashboard = await this.client.apiCall(
+        "PUT",
+        `/api/dashboard/${dashboard_id}/cards`,
+        { cards: existingCards, tabs }
+      );
+    }
+
     return {
       content: [
         {
@@ -400,6 +435,7 @@ export class DashboardToolHandlers {
       size_y = 4,
       parameter_mappings = [],
       visualization_settings = {},
+      dashboard_tab_id,
     } = args;
 
     if (!dashboard_id || !card_id) {
@@ -411,10 +447,10 @@ export class DashboardToolHandlers {
 
     // Try different API approaches based on Metabase version
     let result;
-    
+
     try {
       // Approach 1: Direct POST to dashboard cards (works in some versions)
-      const dashcardData = {
+      const dashcardData: any = {
         cardId: card_id,
         row,
         col,
@@ -423,6 +459,8 @@ export class DashboardToolHandlers {
         parameter_mappings,
         visualization_settings,
       };
+      if (dashboard_tab_id !== undefined)
+        dashcardData.dashboard_tab_id = dashboard_tab_id;
 
       result = await this.client.apiCall(
         "POST",
@@ -449,6 +487,7 @@ export class DashboardToolHandlers {
           size_y,
           parameter_mappings,
           visualization_settings,
+          dashboard_tab_id,
         });
 
         result = await this.client.apiCall(
@@ -458,7 +497,7 @@ export class DashboardToolHandlers {
         );
       } catch (putError) {
         // Approach 3: Try alternative endpoint structure (legacy fallback)
-        const alternativeData = {
+        const alternativeData: any = {
           card_id,
           row,
           col,
@@ -467,6 +506,8 @@ export class DashboardToolHandlers {
           parameter_mappings,
           visualization_settings,
         };
+        if (dashboard_tab_id !== undefined)
+          alternativeData.dashboard_tab_id = dashboard_tab_id;
 
         result = await this.client.apiCall(
           "POST",

--- a/src/handlers/dashboard-tools.ts
+++ b/src/handlers/dashboard-tools.ts
@@ -218,6 +218,38 @@ export class DashboardToolHandlers {
     ];
   }
 
+  /**
+   * Project an existing dashcard to the minimal schema the
+   * `PUT /api/dashboard/:id/cards` endpoint accepts.
+   *
+   * GET responses include many derived fields (nested `card`, timestamps,
+   * `inline_parameters`, etc.) that the PUT handler rejects as "Invalid
+   * Request." Passing them through triggers a generic 400 with no body,
+   * which in previous versions of this code silently fell through and
+   * wiped the dashboard via the `cards: nil` cascade.
+   */
+  private toDashcardPayload(card: any, overrides: Record<string, any> = {}): any {
+    const merged = { ...card, ...overrides };
+    const out: any = {
+      id: merged.id,
+      card_id: merged.card_id ?? null,
+      row: merged.row,
+      col: merged.col,
+      size_x: merged.size_x,
+      size_y: merged.size_y,
+      parameter_mappings: merged.parameter_mappings ?? [],
+      visualization_settings: merged.visualization_settings ?? {},
+      series: Array.isArray(merged.series)
+        ? merged.series.map((s: any) => (typeof s === "number" ? s : s?.id))
+            .filter((v: any) => typeof v === "number")
+        : [],
+    };
+    if (merged.dashboard_tab_id !== undefined && merged.dashboard_tab_id !== null) {
+      out.dashboard_tab_id = merged.dashboard_tab_id;
+    }
+    return out;
+  }
+
   async handleTool(name: string, args: any): Promise<any> {
     switch (name) {
       case "list_dashboards":
@@ -398,13 +430,18 @@ export class DashboardToolHandlers {
         dashcardData
       );
     } catch (error) {
-      // Approach 2: Use PUT to update entire dashboard cards array
+      // Approach 2: Use PUT to update entire dashboard cards array.
+      // Metabase 0.50+ rejects a POST to /cards (404) and only accepts the
+      // PUT /cards bulk endpoint with body `{cards: [...], tabs: [...]}`.
+      // New cards are signalled with a negative id.
       try {
         const dashboard = await this.client.getDashboard(dashboard_id);
-        
-        // Create new card object for the dashboard
-        const newCard = {
-          id: -1, // Temporary ID for new cards
+
+        const existing = (dashboard.dashcards || []).map((c: any) =>
+          this.toDashcardPayload(c)
+        );
+        const newCard = this.toDashcardPayload({
+          id: -1,
           card_id,
           row,
           col,
@@ -412,18 +449,15 @@ export class DashboardToolHandlers {
           size_y,
           parameter_mappings,
           visualization_settings,
-        };
-
-        // Add the new card to existing cards
-        const updatedCards = [...(dashboard.dashcards || []), newCard];
+        });
 
         result = await this.client.apiCall(
           "PUT",
           `/api/dashboard/${dashboard_id}/cards`,
-          { dashcards: updatedCards, tabs: dashboard.tabs || [] }
+          { cards: [...existing, newCard], tabs: dashboard.tabs || [] }
         );
       } catch (putError) {
-        // Approach 3: Try alternative endpoint structure
+        // Approach 3: Try alternative endpoint structure (legacy fallback)
         const alternativeData = {
           card_id,
           row,
@@ -476,16 +510,19 @@ export class DashboardToolHandlers {
           `/api/dashboard/${dashboard_id}/dashcard/${dashcard_id}`
         );
       } catch (altError) {
-        // Approach 3: Update dashboard without the card
+        // Approach 3: Update dashboard without the card via the bulk PUT
+        // endpoint. Body key is `cards` (the request schema); GET responses
+        // use `dashcards`. Mixing the two produces a `cards: nil` cascade
+        // that archives every card on the dashboard.
         const dashboard = await this.client.getDashboard(dashboard_id);
-        const updatedCards = (dashboard.dashcards || []).filter(
-          (card: any) => card.id !== dashcard_id
-        );
+        const updatedCards = (dashboard.dashcards || [])
+          .filter((card: any) => card.id !== dashcard_id)
+          .map((c: any) => this.toDashcardPayload(c));
 
         await this.client.apiCall(
           "PUT",
           `/api/dashboard/${dashboard_id}/cards`,
-          { dashcards: updatedCards, tabs: dashboard.tabs || [] }
+          { cards: updatedCards, tabs: dashboard.tabs || [] }
         );
       }
     }
@@ -535,19 +572,21 @@ export class DashboardToolHandlers {
           updateFields
         );
       } catch (altError) {
-        // Approach 3: Update entire dashboard cards array
+        // Approach 3: Update entire dashboard cards array via the bulk PUT
+        // endpoint. Body key is `cards` (request schema); GET returns
+        // `dashcards`. Using `dashcards` in the body leaves `cards` nil and
+        // Metabase archives every card on the dashboard.
         const dashboard = await this.client.getDashboard(dashboard_id);
-        const updatedCards = (dashboard.dashcards || []).map((card: any) => {
-          if (card.id === dashcard_id) {
-            return { ...card, ...updateFields };
-          }
-          return card;
-        });
+        const updatedCards = (dashboard.dashcards || []).map((card: any) =>
+          card.id === dashcard_id
+            ? this.toDashcardPayload(card, updateFields)
+            : this.toDashcardPayload(card)
+        );
 
         result = await this.client.apiCall(
           "PUT",
           `/api/dashboard/${dashboard_id}/cards`,
-          { dashcards: updatedCards, tabs: dashboard.tabs || [] }
+          { cards: updatedCards, tabs: dashboard.tabs || [] }
         );
       }
     }

--- a/src/types/metabase.ts
+++ b/src/types/metabase.ts
@@ -18,6 +18,7 @@ export interface Dashboard {
   parameters?: any[];
   cards?: DashboardCard[];
   dashcards?: DashboardCard[];
+  tabs?: any[];
 }
 
 export interface DashboardCard {


### PR DESCRIPTION
## Summary

`add_card_to_dashboard`, `remove_card_from_dashboard`, and `update_dashboard_card` all fall through to a **PUT `/api/dashboard/:id/cards` bulk endpoint** (Approach 3) on any Metabase 1.57+, and that fallback path is destructive — it archives every card on the dashboard and deletes all tabs.

This PR replaces the previous attempt (which corrected one side of the asymmetry in the wrong direction) with a verified fix: correct request key, correct response key, and payload filtered to the request schema.

## Root cause

Metabase's dashboard API is **asymmetric**:

| call | body key |
|------|----------|
| `GET  /api/dashboard/:id` response | `dashcards` |
| `PUT  /api/dashboard/:id/cards` request | `cards` |

The pre-PR handler was:

```ts
const dashboard = await this.client.getDashboard(dashboard_id);
const updatedCards = (dashboard.cards || []).filter(...);   // ❌ response uses `dashcards`
await PUT /api/dashboard/:id/cards  { cards: updatedCards } // ✅ request expects `cards`
```

`dashboard.cards` was always `undefined`, coerced to `[]`, so the PUT payload was `{cards: []}` — Metabase treats that as "replace all dashcards with the empty list". Every dashcard is orphaned, the underlying cards are archived and moved to the API user's personal collection, and tabs are wiped (payload omits `tabs` entirely).

On Metabase 1.57+, Approaches 1 and 2 (`PUT /cards/:id` and `PUT /dashcard/:id`) both 404, so the destructive Approach 3 fallback fires on every invocation.

### Why the first commit didn't help

The initial commit on this branch (`5232136`) tried to fix the asymmetry by flipping the write to match the read: `{cards} → {dashcards}`. Reproduced on v1.59.6 with that fix applied — still archives every card. The write was originally correct; the read was wrong.

Metabase's schema validator on v1.59.6 now returns `400 {"specific-errors": {"cards": ["missing required key, received: nil"]}}` for `{dashcards: ...}` bodies, so on latest it's at least loud; on 1.57/1.58 it silently accepts and wipes.

### Second trap: "Invalid Request." 400 on echoed dashcards

Even with the correct `{cards: ...}` key, echoing dashcards straight from `GET /api/dashboard/:id` into the PUT body returns a generic `400 Invalid Request.` (no JSON body). The GET shape includes response-only fields (`card` nested object, `created_at`/`updated_at`, `inline_parameters`, `action_id`, `collection_authority_level`, `dashboard_id`, `entity_id`) that the PUT request schema rejects. Before this fix, that 400 was silently swallowed by the outer `try/catch` and compounded the wipe.

## Reproduction

Metabase v1.57.9 / v1.57.11 / v1.58.7 / v1.59.6:
1. Dashboard with N dashcards (verified at N=19 and N=20).
2. Any one of: `add_card_to_dashboard`, `remove_card_from_dashboard`, `update_dashboard_card`.
3. Tool returns what looks like a success response (`{cards: [], tabs: []}`).
4. `get_dashboard_cards` immediately returns `[]`.
5. All N underlying cards: `archived = true`, moved to the API user's personal collection.

## Changes

- `src/handlers/dashboard-tools.ts`
  - Introduce `toDashcardPayload(card, overrides?)` — projects a dashcard to the fields the PUT request schema accepts (`id`, `card_id`, `row`, `col`, `size_x`, `size_y`, `parameter_mappings`, `visualization_settings`, `series`, `dashboard_tab_id` if present). Normalises `series` to an array of card ids.
  - All three Approach 3 fallbacks now:
    - read `dashboard.dashcards` (response shape)
    - write `{ cards: updatedCards, tabs: dashboard.tabs || [] }` (request shape)
    - route every dashcard through `toDashcardPayload`, so request-incompatible fields never leak into the PUT body.
- `src/types/metabase.ts` (carried forward from the first commit): `tabs?: any[]` on `Dashboard`.

## Test plan

Verified against Metabase v1.59.6 using the built `dist/handlers/dashboard-tools.js` driven directly from Node:

- [x] `update_dashboard_card(dashboard_id, dashcard_id, row/col/size_x/size_y)` — target dashcard moves, all other cards preserved.
- [x] `add_card_to_dashboard(dashboard_id, card_id, row/col/size_x/size_y)` — new dashcard (negative-id entry in payload) persisted, existing cards preserved, new positive `id` returned.
- [x] `remove_card_from_dashboard(dashboard_id, dashcard_id)` — target dashcard removed, all other cards preserved.
- [x] Bulk cleanup (single PUT rewriting 18 cards' positions + deleting 1 + adding a heading virtual card): all 19 cards persisted in the intended layout.
- [x] `npm run build` clean.

## Follow-up (not in this PR)

On Metabase 1.57+, Approaches 1 and 2 are dead paths — they 404 every time, so the outer `try/catch` ladder is effectively just a disguised direct call to Approach 3. Worth flattening to a single code path in a separate PR.