### PR TITLE
fix: resolve 404 errors for get_database_schema and get_database_tables

### DIFF
--- a/src/client/metabase-client.ts
+++ b/src/client/metabase-client.ts
@@ -346,7 +346,8 @@ export class MetabaseClient {
     const response = await this.axiosInstance.request({
       method,
       url: endpoint,
-      data,
+      // GET requests use params (query string); mutations use data (request body)
+      ...(method === "GET" ? { params: data } : { data }),
     });
     return response.data;
   }

--- a/src/handlers/database-tools.ts
+++ b/src/handlers/database-tools.ts
@@ -240,7 +240,7 @@ export class DatabaseToolHandlers {
 
     const tables = await this.client.apiCall(
       "GET",
-      `/api/table?db_id=${database_id}`
+      `/api/database/${database_id}/tables`
     );
     return {
       content: [


### PR DESCRIPTION
Fixes #4

## Root causes

Two separate bugs combined to cause the 404 errors reported in #4.

**1. Deprecated endpoint in `get_database_tables`**

The tool was calling `/api/table?db_id={id}` which was deprecated in Metabase 0.50+. Updated to `/api/database/{id}/tables`.

**2. `apiCall` passing query params as request body on GET requests**

The `apiCall` generic method was forwarding its third argument as `data` (request body) for all HTTP methods. Axios ignores `data` on GET requests — it does not convert it to a query string. This meant any tool passing query parameters via `apiCall` (including `search_content`) was sending malformed requests.

Fixed by routing GET calls through `params` and mutations through `data`:

```ts
...(method === "GET" ? { params: data } : { data }),
```

This explains why direct API calls (curl/PowerShell) worked fine — they constructed the URL correctly — while the MCP tools failed.

## Changes

- `src/handlers/database-tools.ts` — update `get_database_tables` endpoint
- `src/client/metabase-client.ts` — fix `apiCall` query param routing for GET requests

## Test plan

- [ ] `get_database_schema({ database_id: N })` returns schema without 404
- [ ] `get_database_tables({ database_id: N })` returns tables without 404
- [ ] `search_content({ query: "..." })` still works correctly
- [ ] `npm run build` passes cleanly