### PR TITLE
feat: add tool filtering + 33 new tools (tables, sharing, collections, diagnostics)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,36 @@
+# Metabase MCP Server Configuration
+# Copy this file to .env and configure your values
+
+# Required: Your Metabase instance URL
+METABASE_URL=https://your-metabase-instance.com
+
+# Authentication Method 1: API Key (Recommended)
+# Generate an API key from your Metabase admin settings
+METABASE_API_KEY=your_metabase_api_key
+
+# Authentication Method 2: Username/Password (Fallback)
+# Only used if METABASE_API_KEY is not set
+# METABASE_USERNAME=your_username
+# METABASE_PASSWORD=your_password
+
+# Optional: Logging configuration
+LOG_LEVEL=info
+
+# Optional: Node environment
+NODE_ENV=production
+
+# Optional: Request timeout (in milliseconds)
+REQUEST_TIMEOUT=30000
+
+# Optional: Maximum retry attempts for failed requests
+MAX_RETRIES=3
+
+# Optional: Enable debug mode for detailed logging
+DEBUG=false
+
+# Tool filtering mode: essential | read | write | all (default: all)
+# - essential: core read + execute tools only (smallest surface area)
+# - read: all non-destructive tools
+# - write: all tools including create/update/delete
+# - all: every available tool
+TOOL_MODE=all

--- a/src/handlers/card-tools.ts
+++ b/src/handlers/card-tools.ts
@@ -4,7 +4,7 @@
 
 import { MetabaseClient } from "../client/metabase-client.js";
 import { ErrorCode, McpError } from "../types/errors.js";
-import { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { TaggedTool } from "../types/tool-metadata.js";
 
 // Default attributes to return when listing cards (excludes heavy fields like result_metadata)
 const DEFAULT_CARD_ATTRIBUTES = [
@@ -66,11 +66,12 @@ const ALL_CARD_ATTRIBUTES = [
 export class CardToolHandlers {
   constructor(private client: MetabaseClient) {}
 
-  getToolSchemas(): Tool[] {
+  getToolSchemas(): TaggedTool[] {
     return [
       {
         name: "list_cards",
         description: "List all questions/cards in Metabase",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["card"] },
         inputSchema: {
           type: "object",
           properties: {
@@ -88,6 +89,7 @@ export class CardToolHandlers {
       {
         name: "get_card",
         description: "Get a single Metabase question/card by ID with full details including the SQL query (dataset_query). Returns MBQL 5 by default.",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["card"] },
         inputSchema: {
           type: "object",
           properties: {
@@ -102,6 +104,7 @@ export class CardToolHandlers {
       {
         name: "create_card",
         description: "Create a new Metabase question (card)",
+        metadata: { mode: ["write", "all"], tags: ["card"] },
         inputSchema: {
           type: "object",
           properties: {
@@ -139,6 +142,7 @@ export class CardToolHandlers {
       {
         name: "update_card",
         description: "Update an existing Metabase question (card)",
+        metadata: { mode: ["write", "all"], tags: ["card"] },
         inputSchema: {
           type: "object",
           properties: {
@@ -169,6 +173,7 @@ export class CardToolHandlers {
       {
         name: "delete_card",
         description: "Delete a Metabase question (card)",
+        metadata: { mode: ["write", "all"], tags: ["card"] },
         inputSchema: {
           type: "object",
           properties: {
@@ -189,6 +194,7 @@ export class CardToolHandlers {
       {
         name: "execute_card",
         description: "Execute a Metabase question/card and get results",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["card"] },
         inputSchema: {
           type: "object",
           properties: {

--- a/src/handlers/card-tools.ts
+++ b/src/handlers/card-tools.ts
@@ -210,6 +210,103 @@ export class CardToolHandlers {
           required: ["card_id"],
         },
       },
+      {
+        name: "create_card_public_link",
+        description: "Create a public sharing link for a card/question. Returns the UUID for the public URL.",
+        metadata: { mode: ["write", "all"], tags: ["card", "sharing"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            card_id: { type: "number", description: "ID of the card to share" },
+          },
+          required: ["card_id"],
+        },
+      },
+      {
+        name: "delete_card_public_link",
+        description: "Remove the public sharing link for a card/question",
+        metadata: { mode: ["write", "all"], tags: ["card", "sharing"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            card_id: { type: "number", description: "ID of the card" },
+          },
+          required: ["card_id"],
+        },
+      },
+      {
+        name: "list_public_cards",
+        description: "List all cards that have public sharing links enabled",
+        metadata: { mode: ["read", "write", "all"], tags: ["card", "sharing"] },
+        inputSchema: { type: "object", properties: {} },
+      },
+      {
+        name: "list_embeddable_cards",
+        description: "List all cards that are set up for embedding",
+        metadata: { mode: ["read", "write", "all"], tags: ["card", "sharing"] },
+        inputSchema: { type: "object", properties: {} },
+      },
+      {
+        name: "export_card_result",
+        description: "Export a card's query results in the specified format (csv, json, xlsx)",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["card"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            card_id: { type: "number", description: "ID of the card to export" },
+            format: {
+              type: "string",
+              enum: ["csv", "json", "xlsx"],
+              description: "Export format",
+              default: "json",
+            },
+            parameters: {
+              type: "array",
+              description: "Optional query parameters",
+              items: { type: "object" },
+            },
+          },
+          required: ["card_id"],
+        },
+      },
+      {
+        name: "copy_card",
+        description: "Duplicate an existing card/question",
+        metadata: { mode: ["write", "all"], tags: ["card"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            card_id: { type: "number", description: "ID of the card to copy" },
+            name: { type: "string", description: "Name for the copy (defaults to 'Copy of <original>')" },
+            collection_id: { type: "number", description: "Collection to place the copy in" },
+          },
+          required: ["card_id"],
+        },
+      },
+      {
+        name: "get_card_query_metadata",
+        description: "Get query metadata for a card including column types and display names",
+        metadata: { mode: ["read", "write", "all"], tags: ["card"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            card_id: { type: "number", description: "ID of the card" },
+          },
+          required: ["card_id"],
+        },
+      },
+      {
+        name: "get_card_dashboards",
+        description: "List all dashboards that contain a specific card",
+        metadata: { mode: ["read", "write", "all"], tags: ["card"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            card_id: { type: "number", description: "ID of the card" },
+          },
+          required: ["card_id"],
+        },
+      },
     ];
   }
 
@@ -232,6 +329,23 @@ export class CardToolHandlers {
 
       case "execute_card":
         return await this.executeCard(args);
+
+      case "create_card_public_link":
+        return await this.createPublicLink(args);
+      case "delete_card_public_link":
+        return await this.deletePublicLink(args);
+      case "list_public_cards":
+        return await this.listPublicCards();
+      case "list_embeddable_cards":
+        return await this.listEmbeddableCards();
+      case "export_card_result":
+        return await this.exportCardResult(args);
+      case "copy_card":
+        return await this.copyCard(args);
+      case "get_card_query_metadata":
+        return await this.getCardQueryMetadata(args);
+      case "get_card_dashboards":
+        return await this.getCardDashboards(args);
 
       default:
         throw new McpError(
@@ -383,5 +497,64 @@ export class CardToolHandlers {
         },
       ],
     };
+  }
+
+  private async createPublicLink(args: any): Promise<any> {
+    const { card_id } = args;
+    if (!card_id) throw new McpError(ErrorCode.InvalidParams, "card_id is required");
+    const result = await this.client.apiCall("POST", `/api/card/${card_id}/public_link`);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async deletePublicLink(args: any): Promise<any> {
+    const { card_id } = args;
+    if (!card_id) throw new McpError(ErrorCode.InvalidParams, "card_id is required");
+    await this.client.apiCall("DELETE", `/api/card/${card_id}/public_link`);
+    return { content: [{ type: "text", text: `Public link for card ${card_id} removed.` }] };
+  }
+
+  private async listPublicCards(): Promise<any> {
+    const cards = await this.client.apiCall("GET", `/api/card/public`);
+    return { content: [{ type: "text", text: JSON.stringify(cards, null, 2) }] };
+  }
+
+  private async listEmbeddableCards(): Promise<any> {
+    const cards = await this.client.apiCall("GET", `/api/card/embeddable`);
+    return { content: [{ type: "text", text: JSON.stringify(cards, null, 2) }] };
+  }
+
+  private async exportCardResult(args: any): Promise<any> {
+    const { card_id, format = "json", parameters = [] } = args;
+    if (!card_id) throw new McpError(ErrorCode.InvalidParams, "card_id is required");
+    const result = await this.client.apiCall(
+      "POST",
+      `/api/card/${card_id}/query/${format}`,
+      { parameters }
+    );
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async copyCard(args: any): Promise<any> {
+    const { card_id, name, collection_id } = args;
+    if (!card_id) throw new McpError(ErrorCode.InvalidParams, "card_id is required");
+    const body: any = {};
+    if (name) body.name = name;
+    if (collection_id !== undefined) body.collection_id = collection_id;
+    const result = await this.client.apiCall("POST", `/api/card/${card_id}/copy`, body);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async getCardQueryMetadata(args: any): Promise<any> {
+    const { card_id } = args;
+    if (!card_id) throw new McpError(ErrorCode.InvalidParams, "card_id is required");
+    const result = await this.client.apiCall("GET", `/api/card/${card_id}/query_metadata`);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async getCardDashboards(args: any): Promise<any> {
+    const { card_id } = args;
+    if (!card_id) throw new McpError(ErrorCode.InvalidParams, "card_id is required");
+    const result = await this.client.apiCall("GET", `/api/card/${card_id}/dashboards`);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
   }
 }

--- a/src/handlers/card-tools.ts
+++ b/src/handlers/card-tools.ts
@@ -526,6 +526,9 @@ export class CardToolHandlers {
   private async exportCardResult(args: any): Promise<any> {
     const { card_id, format = "json", parameters = [] } = args;
     if (!card_id) throw new McpError(ErrorCode.InvalidParams, "card_id is required");
+    if (format === "xlsx") {
+      return { content: [{ type: "text", text: "xlsx export is not supported via MCP — use csv or json format instead" }] };
+    }
     const result = await this.client.apiCall(
       "POST",
       `/api/card/${card_id}/query/${format}`,

--- a/src/handlers/dashboard-tools.ts
+++ b/src/handlers/dashboard-tools.ts
@@ -239,6 +239,98 @@ export class DashboardToolHandlers {
           required: ["dashboard_id", "dashcard_id"],
         },
       },
+      {
+        name: "create_dashboard_public_link",
+        description: "Create a public sharing link for a dashboard. Returns the UUID for the public URL.",
+        metadata: { mode: ["write", "all"], tags: ["dashboard", "sharing"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            dashboard_id: { type: "number", description: "ID of the dashboard to share" },
+          },
+          required: ["dashboard_id"],
+        },
+      },
+      {
+        name: "delete_dashboard_public_link",
+        description: "Remove the public sharing link for a dashboard",
+        metadata: { mode: ["write", "all"], tags: ["dashboard", "sharing"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            dashboard_id: { type: "number", description: "ID of the dashboard" },
+          },
+          required: ["dashboard_id"],
+        },
+      },
+      {
+        name: "list_public_dashboards",
+        description: "List all dashboards that have public sharing links enabled",
+        metadata: { mode: ["read", "write", "all"], tags: ["dashboard", "sharing"] },
+        inputSchema: { type: "object", properties: {} },
+      },
+      {
+        name: "list_embeddable_dashboards",
+        description: "List all dashboards that are set up for embedding",
+        metadata: { mode: ["read", "write", "all"], tags: ["dashboard", "sharing"] },
+        inputSchema: { type: "object", properties: {} },
+      },
+      {
+        name: "copy_dashboard",
+        description: "Duplicate a dashboard with all its cards",
+        metadata: { mode: ["write", "all"], tags: ["dashboard"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            dashboard_id: { type: "number", description: "ID of the dashboard to copy" },
+            name: { type: "string", description: "Name for the copy" },
+            collection_id: { type: "number", description: "Collection to place the copy in" },
+            is_deep_copy: {
+              type: "boolean",
+              description: "Copy underlying cards too (default: false = shallow copy)",
+              default: false,
+            },
+          },
+          required: ["dashboard_id"],
+        },
+      },
+      {
+        name: "get_dashboard_revisions",
+        description: "Get revision history for a dashboard (audit trail)",
+        metadata: { mode: ["read", "write", "all"], tags: ["dashboard"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            dashboard_id: { type: "number", description: "ID of the dashboard" },
+          },
+          required: ["dashboard_id"],
+        },
+      },
+      {
+        name: "revert_dashboard",
+        description: "Revert a dashboard to a previous revision",
+        metadata: { mode: ["write", "all"], tags: ["dashboard"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            dashboard_id: { type: "number", description: "ID of the dashboard" },
+            revision_id: { type: "number", description: "ID of the revision to revert to" },
+          },
+          required: ["dashboard_id", "revision_id"],
+        },
+      },
+      {
+        name: "get_dashboard_related",
+        description: "Get related content suggestions for a dashboard",
+        metadata: { mode: ["read", "write", "all"], tags: ["dashboard"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            dashboard_id: { type: "number", description: "ID of the dashboard" },
+          },
+          required: ["dashboard_id"],
+        },
+      },
     ];
   }
 
@@ -299,6 +391,23 @@ export class DashboardToolHandlers {
 
       case "update_dashboard_card":
         return await this.updateDashboardCard(args);
+
+      case "create_dashboard_public_link":
+        return await this.createPublicLink(args);
+      case "delete_dashboard_public_link":
+        return await this.deletePublicLink(args);
+      case "list_public_dashboards":
+        return await this.listPublicDashboards();
+      case "list_embeddable_dashboards":
+        return await this.listEmbeddableDashboards();
+      case "copy_dashboard":
+        return await this.copyDashboard(args);
+      case "get_dashboard_revisions":
+        return await this.getDashboardRevisions(args);
+      case "revert_dashboard":
+        return await this.revertDashboard(args);
+      case "get_dashboard_related":
+        return await this.getDashboardRelated(args);
 
       default:
         throw new McpError(
@@ -604,7 +713,7 @@ export class DashboardToolHandlers {
     }
 
     let result;
-    
+
     try {
       // Approach 1: Direct PUT to specific card
       result = await this.client.apiCall(
@@ -648,5 +757,67 @@ export class DashboardToolHandlers {
         },
       ],
     };
+  }
+
+  private async createPublicLink(args: any): Promise<any> {
+    const { dashboard_id } = args;
+    if (!dashboard_id) throw new McpError(ErrorCode.InvalidParams, "dashboard_id is required");
+    const result = await this.client.apiCall("POST", `/api/dashboard/${dashboard_id}/public_link`);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async deletePublicLink(args: any): Promise<any> {
+    const { dashboard_id } = args;
+    if (!dashboard_id) throw new McpError(ErrorCode.InvalidParams, "dashboard_id is required");
+    await this.client.apiCall("DELETE", `/api/dashboard/${dashboard_id}/public_link`);
+    return { content: [{ type: "text", text: `Public link for dashboard ${dashboard_id} removed.` }] };
+  }
+
+  private async listPublicDashboards(): Promise<any> {
+    const dashboards = await this.client.apiCall("GET", `/api/dashboard/public`);
+    return { content: [{ type: "text", text: JSON.stringify(dashboards, null, 2) }] };
+  }
+
+  private async listEmbeddableDashboards(): Promise<any> {
+    const dashboards = await this.client.apiCall("GET", `/api/dashboard/embeddable`);
+    return { content: [{ type: "text", text: JSON.stringify(dashboards, null, 2) }] };
+  }
+
+  private async copyDashboard(args: any): Promise<any> {
+    const { dashboard_id, name, collection_id, is_deep_copy = false } = args;
+    if (!dashboard_id) throw new McpError(ErrorCode.InvalidParams, "dashboard_id is required");
+    const body: any = { is_deep_copy };
+    if (name) body.name = name;
+    if (collection_id !== undefined) body.collection_id = collection_id;
+    const result = await this.client.apiCall("POST", `/api/dashboard/${dashboard_id}/copy`, body);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async getDashboardRevisions(args: any): Promise<any> {
+    const { dashboard_id } = args;
+    if (!dashboard_id) throw new McpError(ErrorCode.InvalidParams, "dashboard_id is required");
+    const revisions = await this.client.apiCall(
+      "GET", `/api/revision`, { entity: "dashboard", id: dashboard_id }
+    );
+    return { content: [{ type: "text", text: JSON.stringify(revisions, null, 2) }] };
+  }
+
+  private async revertDashboard(args: any): Promise<any> {
+    const { dashboard_id, revision_id } = args;
+    if (!dashboard_id || !revision_id) {
+      throw new McpError(ErrorCode.InvalidParams, "dashboard_id and revision_id are required");
+    }
+    const result = await this.client.apiCall(
+      "POST", `/api/revision/revert`,
+      { entity: "dashboard", id: dashboard_id, revision_id }
+    );
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async getDashboardRelated(args: any): Promise<any> {
+    const { dashboard_id } = args;
+    if (!dashboard_id) throw new McpError(ErrorCode.InvalidParams, "dashboard_id is required");
+    const result = await this.client.apiCall("GET", `/api/dashboard/${dashboard_id}/related`);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
   }
 }

--- a/src/handlers/dashboard-tools.ts
+++ b/src/handlers/dashboard-tools.ts
@@ -4,16 +4,17 @@
 
 import { MetabaseClient } from "../client/metabase-client.js";
 import { ErrorCode, McpError } from "../types/errors.js";
-import { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { TaggedTool } from "../types/tool-metadata.js";
 
 export class DashboardToolHandlers {
   constructor(private client: MetabaseClient) {}
 
-  getToolSchemas(): Tool[] {
+  getToolSchemas(): TaggedTool[] {
     return [
       {
         name: "list_dashboards",
         description: "List all dashboards in Metabase",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["dashboard"] },
         inputSchema: {
           type: "object",
           properties: {},
@@ -22,6 +23,7 @@ export class DashboardToolHandlers {
       {
         name: "create_dashboard",
         description: "Create a new Metabase dashboard",
+        metadata: { mode: ["write", "all"], tags: ["dashboard"] },
         inputSchema: {
           type: "object",
           properties: {
@@ -47,6 +49,7 @@ export class DashboardToolHandlers {
       {
         name: "update_dashboard",
         description: "Update an existing Metabase dashboard",
+        metadata: { mode: ["write", "all"], tags: ["dashboard"] },
         inputSchema: {
           type: "object",
           properties: {
@@ -82,6 +85,7 @@ export class DashboardToolHandlers {
       {
         name: "delete_dashboard",
         description: "Delete a Metabase dashboard",
+        metadata: { mode: ["write", "all"], tags: ["dashboard"] },
         inputSchema: {
           type: "object",
           properties: {
@@ -102,6 +106,7 @@ export class DashboardToolHandlers {
       {
         name: "get_dashboard_cards",
         description: "Get all cards in a dashboard",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["dashboard"] },
         inputSchema: {
           type: "object",
           properties: {
@@ -116,6 +121,7 @@ export class DashboardToolHandlers {
       {
         name: "add_card_to_dashboard",
         description: "Add a card to a dashboard with positioning",
+        metadata: { mode: ["write", "all"], tags: ["dashboard"] },
         inputSchema: {
           type: "object",
           properties: {
@@ -168,6 +174,7 @@ export class DashboardToolHandlers {
       {
         name: "remove_card_from_dashboard",
         description: "Remove a card from a dashboard",
+        metadata: { mode: ["write", "all"], tags: ["dashboard"] },
         inputSchema: {
           type: "object",
           properties: {
@@ -186,6 +193,7 @@ export class DashboardToolHandlers {
       {
         name: "update_dashboard_card",
         description: "Update card position, size, and settings on a dashboard",
+        metadata: { mode: ["write", "all"], tags: ["dashboard"] },
         inputSchema: {
           type: "object",
           properties: {

--- a/src/handlers/database-tools.ts
+++ b/src/handlers/database-tools.ts
@@ -144,6 +144,55 @@ export class DatabaseToolHandlers {
           required: ["database_id"],
         },
       },
+      {
+        name: "check_database_health",
+        description: "Check the connection health of a database",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["database"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            database_id: { type: "number", description: "ID of the database" },
+          },
+          required: ["database_id"],
+        },
+      },
+      {
+        name: "validate_database",
+        description: "Validate a database connection before saving",
+        metadata: { mode: ["write", "all"], tags: ["database"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            engine: { type: "string", description: "Database engine (postgres, mysql, etc.)" },
+            details: { type: "object", description: "Connection details to validate" },
+          },
+          required: ["engine", "details"],
+        },
+      },
+      {
+        name: "list_database_schemas",
+        description: "List all schemas within a database",
+        metadata: { mode: ["read", "write", "all"], tags: ["database"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            database_id: { type: "number", description: "ID of the database" },
+          },
+          required: ["database_id"],
+        },
+      },
+      {
+        name: "get_database_metadata",
+        description: "Get full metadata for a database including all tables and fields with their IDs. This is the authoritative source for field IDs needed in MBQL queries.",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["database"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            database_id: { type: "number", description: "ID of the database" },
+          },
+          required: ["database_id"],
+        },
+      },
     ];
   }
 
@@ -172,6 +221,15 @@ export class DatabaseToolHandlers {
 
       case "get_database_sync_status":
         return await this.getDatabaseSyncStatus(args);
+
+      case "check_database_health":
+        return await this.checkDatabaseHealth(args);
+      case "validate_database":
+        return await this.validateDatabase(args);
+      case "list_database_schemas":
+        return await this.listDatabaseSchemas(args);
+      case "get_database_metadata":
+        return await this.getDatabaseMetadataTool(args);
 
       default:
         throw new McpError(
@@ -377,5 +435,33 @@ export class DatabaseToolHandlers {
         },
       ],
     };
+  }
+
+  private async checkDatabaseHealth(args: any): Promise<any> {
+    const { database_id } = args;
+    if (!database_id) throw new McpError(ErrorCode.InvalidParams, "database_id is required");
+    const result = await this.client.apiCall("GET", `/api/database/${database_id}/health`);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async validateDatabase(args: any): Promise<any> {
+    const { engine, details } = args;
+    if (!engine || !details) throw new McpError(ErrorCode.InvalidParams, "engine and details are required");
+    const result = await this.client.apiCall("POST", `/api/database/validate`, { engine, details });
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async listDatabaseSchemas(args: any): Promise<any> {
+    const { database_id } = args;
+    if (!database_id) throw new McpError(ErrorCode.InvalidParams, "database_id is required");
+    const schemas = await this.client.apiCall("GET", `/api/database/${database_id}/schemas`);
+    return { content: [{ type: "text", text: JSON.stringify(schemas, null, 2) }] };
+  }
+
+  private async getDatabaseMetadataTool(args: any): Promise<any> {
+    const { database_id } = args;
+    if (!database_id) throw new McpError(ErrorCode.InvalidParams, "database_id is required");
+    const metadata = await this.client.apiCall("GET", `/api/database/${database_id}/metadata`);
+    return { content: [{ type: "text", text: JSON.stringify(metadata, null, 2) }] };
   }
 }

--- a/src/handlers/database-tools.ts
+++ b/src/handlers/database-tools.ts
@@ -4,16 +4,17 @@
 
 import { MetabaseClient } from "../client/metabase-client.js";
 import { ErrorCode, McpError } from "../types/errors.js";
-import { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { TaggedTool } from "../types/tool-metadata.js";
 
 export class DatabaseToolHandlers {
   constructor(private client: MetabaseClient) { }
 
-  getToolSchemas(): Tool[] {
+  getToolSchemas(): TaggedTool[] {
     return [
       {
         name: "list_databases",
         description: "List all databases in Metabase",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["database"] },
         inputSchema: {
           type: "object",
           properties: {},
@@ -22,6 +23,7 @@ export class DatabaseToolHandlers {
       {
         name: "execute_query",
         description: "Execute a SQL query against a Metabase database",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["database"] },
         inputSchema: {
           type: "object",
           properties: {
@@ -42,6 +44,7 @@ export class DatabaseToolHandlers {
       {
         name: "get_database_schema",
         description: "Get the schema information for a database",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["database"] },
         inputSchema: {
           type: "object",
           properties: {
@@ -53,6 +56,7 @@ export class DatabaseToolHandlers {
       {
         name: "get_database_tables",
         description: "Get all tables in a database",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["database"] },
         inputSchema: {
           type: "object",
           properties: {
@@ -64,6 +68,7 @@ export class DatabaseToolHandlers {
       {
         name: "create_database_connection",
         description: "Create a new database connection",
+        metadata: { mode: ["write", "all"], tags: ["database"] },
         inputSchema: {
           type: "object",
           properties: {
@@ -97,6 +102,7 @@ export class DatabaseToolHandlers {
       {
         name: "test_database_connection",
         description: "Test a database connection",
+        metadata: { mode: ["read", "write", "all"], tags: ["database"] },
         inputSchema: {
           type: "object",
           properties: {
@@ -114,6 +120,7 @@ export class DatabaseToolHandlers {
       {
         name: "sync_database_schema",
         description: "Sync database schema metadata",
+        metadata: { mode: ["write", "all"], tags: ["database"] },
         inputSchema: {
           type: "object",
           properties: {
@@ -128,6 +135,7 @@ export class DatabaseToolHandlers {
       {
         name: "get_database_sync_status",
         description: "Get database schema sync status",
+        metadata: { mode: ["read", "write", "all"], tags: ["database"] },
         inputSchema: {
           type: "object",
           properties: {

--- a/src/handlers/table-tools.ts
+++ b/src/handlers/table-tools.ts
@@ -1,0 +1,248 @@
+// src/handlers/table-tools.ts
+import { MetabaseClient } from "../client/metabase-client.js";
+import { ErrorCode, McpError } from "../types/errors.js";
+import { TaggedTool } from "../types/tool-metadata.js";
+
+export class TableToolHandlers {
+  constructor(private client: MetabaseClient) {}
+
+  getToolSchemas(): TaggedTool[] {
+    return [
+      {
+        name: "list_tables",
+        description: "List all tables across all databases in Metabase",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["table"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            database_id: {
+              type: "number",
+              description: "Optional: filter tables by database ID",
+            },
+          },
+        },
+      },
+      {
+        name: "get_table",
+        description: "Get metadata for a specific table by ID",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["table"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            table_id: { type: "number", description: "ID of the table" },
+          },
+          required: ["table_id"],
+        },
+      },
+      {
+        name: "get_table_metadata",
+        description: "Get full query metadata for a table including all fields with their IDs, types, and semantic types. Use this to get field IDs needed for MBQL queries.",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["table"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            table_id: { type: "number", description: "ID of the table" },
+            include_sensitive_fields: {
+              type: "boolean",
+              description: "Include sensitive fields (default: false)",
+              default: false,
+            },
+          },
+          required: ["table_id"],
+        },
+      },
+      {
+        name: "get_table_fks",
+        description: "Get all foreign key relationships for a table",
+        metadata: { mode: ["read", "write", "all"], tags: ["table"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            table_id: { type: "number", description: "ID of the table" },
+          },
+          required: ["table_id"],
+        },
+      },
+      {
+        name: "get_field_id",
+        description: "Look up the Metabase field ID for a column by table ID and column name. Essential for building MBQL queries.",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["table"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            table_id: { type: "number", description: "ID of the table" },
+            field_name: { type: "string", description: "Column name to look up (case-insensitive)" },
+          },
+          required: ["table_id", "field_name"],
+        },
+      },
+      {
+        name: "update_table",
+        description: "Update table metadata (display name, description, visibility)",
+        metadata: { mode: ["write", "all"], tags: ["table"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            table_id: { type: "number", description: "ID of the table" },
+            display_name: { type: "string", description: "New display name" },
+            description: { type: "string", description: "Table description" },
+            visibility_type: {
+              type: "string",
+              enum: ["normal", "hidden", "technical", "cruft"],
+              description: "Table visibility in the UI",
+            },
+          },
+          required: ["table_id"],
+        },
+      },
+      {
+        name: "sync_table_schema",
+        description: "Trigger a schema sync for a specific table",
+        metadata: { mode: ["write", "all"], tags: ["table"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            table_id: { type: "number", description: "ID of the table" },
+          },
+          required: ["table_id"],
+        },
+      },
+      {
+        name: "rescan_table_field_values",
+        description: "Rescan field values for a table (updates filter dropdowns)",
+        metadata: { mode: ["write", "all"], tags: ["table"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            table_id: { type: "number", description: "ID of the table" },
+          },
+          required: ["table_id"],
+        },
+      },
+      {
+        name: "discard_table_field_values",
+        description: "Discard cached field values for a table",
+        metadata: { mode: ["write", "all"], tags: ["table"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            table_id: { type: "number", description: "ID of the table" },
+          },
+          required: ["table_id"],
+        },
+      },
+    ];
+  }
+
+  async handleTool(name: string, args: any): Promise<any> {
+    switch (name) {
+      case "list_tables":       return await this.listTables(args);
+      case "get_table":         return await this.getTable(args);
+      case "get_table_metadata": return await this.getTableMetadata(args);
+      case "get_table_fks":     return await this.getTableFks(args);
+      case "get_field_id":      return await this.getFieldId(args);
+      case "update_table":      return await this.updateTable(args);
+      case "sync_table_schema": return await this.syncTableSchema(args);
+      case "rescan_table_field_values": return await this.rescanTableFieldValues(args);
+      case "discard_table_field_values": return await this.discardTableFieldValues(args);
+      default:
+        throw new McpError(ErrorCode.MethodNotFound, `Unknown table tool: ${name}`);
+    }
+  }
+
+  private async listTables(args: any): Promise<any> {
+    const { database_id } = args ?? {};
+    const endpoint = database_id
+      ? `/api/database/${database_id}/tables`
+      : `/api/table`;
+    const tables = await this.client.apiCall("GET", endpoint);
+    return { content: [{ type: "text", text: JSON.stringify(tables, null, 2) }] };
+  }
+
+  private async getTable(args: any): Promise<any> {
+    const { table_id } = args;
+    if (!table_id) throw new McpError(ErrorCode.InvalidParams, "table_id is required");
+    const table = await this.client.apiCall("GET", `/api/table/${table_id}`);
+    return { content: [{ type: "text", text: JSON.stringify(table, null, 2) }] };
+  }
+
+  private async getTableMetadata(args: any): Promise<any> {
+    const { table_id, include_sensitive_fields = false } = args;
+    if (!table_id) throw new McpError(ErrorCode.InvalidParams, "table_id is required");
+    const metadata = await this.client.apiCall(
+      "GET",
+      `/api/table/${table_id}/query_metadata`,
+      { include_sensitive_fields }
+    );
+    return { content: [{ type: "text", text: JSON.stringify(metadata, null, 2) }] };
+  }
+
+  private async getTableFks(args: any): Promise<any> {
+    const { table_id } = args;
+    if (!table_id) throw new McpError(ErrorCode.InvalidParams, "table_id is required");
+    const fks = await this.client.apiCall("GET", `/api/table/${table_id}/fks`);
+    return { content: [{ type: "text", text: JSON.stringify(fks, null, 2) }] };
+  }
+
+  private async getFieldId(args: any): Promise<any> {
+    const { table_id, field_name } = args;
+    if (!table_id || !field_name) {
+      throw new McpError(ErrorCode.InvalidParams, "table_id and field_name are required");
+    }
+    const metadata = await this.client.apiCall(
+      "GET",
+      `/api/table/${table_id}/query_metadata`
+    );
+    const field = (metadata.fields ?? []).find(
+      (f: any) => f.name?.toLowerCase() === field_name.toLowerCase()
+    );
+    if (!field) {
+      const available = (metadata.fields ?? []).map((f: any) => f.name).join(", ");
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Field "${field_name}" not found in table ${table_id}. Available: ${available}`
+      );
+    }
+    return {
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          field_id: field.id,
+          name: field.name,
+          display_name: field.display_name,
+          base_type: field.base_type,
+          semantic_type: field.semantic_type,
+          mbql_ref: ["field", field.id, null],
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async updateTable(args: any): Promise<any> {
+    const { table_id, ...updates } = args;
+    if (!table_id) throw new McpError(ErrorCode.InvalidParams, "table_id is required");
+    const result = await this.client.apiCall("PUT", `/api/table/${table_id}`, updates);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async syncTableSchema(args: any): Promise<any> {
+    const { table_id } = args;
+    if (!table_id) throw new McpError(ErrorCode.InvalidParams, "table_id is required");
+    await this.client.apiCall("POST", `/api/table/${table_id}/sync`);
+    return { content: [{ type: "text", text: `Table ${table_id} schema sync triggered.` }] };
+  }
+
+  private async rescanTableFieldValues(args: any): Promise<any> {
+    const { table_id } = args;
+    if (!table_id) throw new McpError(ErrorCode.InvalidParams, "table_id is required");
+    await this.client.apiCall("POST", `/api/table/${table_id}/rescan_values`);
+    return { content: [{ type: "text", text: `Table ${table_id} field values rescan triggered.` }] };
+  }
+
+  private async discardTableFieldValues(args: any): Promise<any> {
+    const { table_id } = args;
+    if (!table_id) throw new McpError(ErrorCode.InvalidParams, "table_id is required");
+    await this.client.apiCall("POST", `/api/table/${table_id}/discard_values`);
+    return { content: [{ type: "text", text: `Table ${table_id} field values discarded.` }] };
+  }
+}

--- a/src/handlers/tool-registry.ts
+++ b/src/handlers/tool-registry.ts
@@ -111,6 +111,14 @@ export class ToolRegistry {
         "add_card_to_dashboard",
         "remove_card_from_dashboard",
         "update_dashboard_card",
+        "create_dashboard_public_link",
+        "delete_dashboard_public_link",
+        "list_public_dashboards",
+        "list_embeddable_dashboards",
+        "copy_dashboard",
+        "get_dashboard_revisions",
+        "revert_dashboard",
+        "get_dashboard_related",
       ].includes(name)
     );
   }
@@ -125,6 +133,14 @@ export class ToolRegistry {
         "update_card",
         "delete_card",
         "execute_card",
+        "create_card_public_link",
+        "delete_card_public_link",
+        "list_public_cards",
+        "list_embeddable_cards",
+        "export_card_result",
+        "copy_card",
+        "get_card_query_metadata",
+        "get_card_dashboards",
       ].includes(name)
     );
   }
@@ -142,6 +158,10 @@ export class ToolRegistry {
         "test_database_connection",
         "sync_database_schema",
         "get_database_sync_status",
+        "check_database_health",
+        "validate_database",
+        "list_database_schemas",
+        "get_database_metadata",
       ].includes(name)
     );
   }
@@ -192,6 +212,65 @@ export class ToolRegistry {
           required: ["name"],
         },
         metadata: { mode: ["write", "all"], tags: ["collection"] },
+      },
+      {
+        name: "get_collection",
+        description: "Get details of a specific collection",
+        metadata: { mode: ["read", "write", "all"], tags: ["collection"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            collection_id: { type: ["number", "string"], description: "ID of the collection (use 'root' for root collection)" },
+          },
+          required: ["collection_id"],
+        },
+      },
+      {
+        name: "update_collection",
+        description: "Update a collection's name, description, color, or parent",
+        metadata: { mode: ["write", "all"], tags: ["collection"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            collection_id: { type: "number", description: "ID of the collection" },
+            name: { type: "string", description: "New name" },
+            description: { type: "string" },
+            color: { type: "string", description: "Hex color e.g. #31698A" },
+            parent_id: { type: "number", description: "New parent collection ID" },
+          },
+          required: ["collection_id"],
+        },
+      },
+      {
+        name: "delete_collection",
+        description: "Delete a collection and all its contents",
+        metadata: { mode: ["write", "all"], tags: ["collection"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            collection_id: { type: "number", description: "ID of the collection to delete" },
+          },
+          required: ["collection_id"],
+        },
+      },
+      {
+        name: "get_collection_items",
+        description: "List items (cards, dashboards, sub-collections) inside a collection",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["collection"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            collection_id: {
+              type: "number",
+              description: "ID of the collection (omit or use null for root)",
+            },
+            models: {
+              type: "array",
+              description: "Filter by content type",
+              items: { type: "string", enum: ["card", "dashboard", "collection", "dataset"] },
+            },
+          },
+        },
       },
       // User tools
       {
@@ -285,6 +364,14 @@ export class ToolRegistry {
         return await this.handleListCollections(args);
       case "create_collection":
         return await this.handleCreateCollection(args);
+      case "get_collection":
+        return await this.handleGetCollection(args);
+      case "update_collection":
+        return await this.handleUpdateCollection(args);
+      case "delete_collection":
+        return await this.handleDeleteCollection(args);
+      case "get_collection_items":
+        return await this.handleGetCollectionItems(args);
 
       // User operations
       case "list_users":
@@ -435,5 +522,32 @@ export class ToolRegistry {
         },
       ],
     };
+  }
+
+  private async handleGetCollection(args: any): Promise<any> {
+    const { collection_id } = args;
+    const result = await this.client.apiCall("GET", `/api/collection/${collection_id}`);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async handleUpdateCollection(args: any): Promise<any> {
+    const { collection_id, ...updates } = args;
+    const result = await this.client.apiCall("PUT", `/api/collection/${collection_id}`, updates);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async handleDeleteCollection(args: any): Promise<any> {
+    const { collection_id } = args;
+    await this.client.apiCall("DELETE", `/api/collection/${collection_id}`);
+    return { content: [{ type: "text", text: `Collection ${collection_id} deleted.` }] };
+  }
+
+  private async handleGetCollectionItems(args: any): Promise<any> {
+    const { collection_id, models } = args;
+    const id = collection_id ?? "root";
+    const params: any = {};
+    if (models?.length) params.models = models.join(",");
+    const result = await this.client.apiCall("GET", `/api/collection/${id}/items`, params);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
   }
 }

--- a/src/handlers/tool-registry.ts
+++ b/src/handlers/tool-registry.ts
@@ -6,6 +6,7 @@ import { MetabaseClient } from "../client/metabase-client.js";
 import { DashboardToolHandlers } from "./dashboard-tools.js";
 import { CardToolHandlers } from "./card-tools.js";
 import { DatabaseToolHandlers } from "./database-tools.js";
+import { TableToolHandlers } from "./table-tools.js";
 import { ErrorCode, McpError } from "../types/errors.js";
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { ToolMode, TaggedTool } from "../types/tool-metadata.js";
@@ -14,6 +15,7 @@ export class ToolRegistry {
   private dashboardHandlers: DashboardToolHandlers;
   private cardHandlers: CardToolHandlers;
   private databaseHandlers: DatabaseToolHandlers;
+  private tableHandlers: TableToolHandlers;
   private toolMode: ToolMode;
   private visibleToolNames: Set<string> | null = null;
 
@@ -21,6 +23,7 @@ export class ToolRegistry {
     this.dashboardHandlers = new DashboardToolHandlers(client);
     this.cardHandlers = new CardToolHandlers(client);
     this.databaseHandlers = new DatabaseToolHandlers(client);
+    this.tableHandlers = new TableToolHandlers(client);
 
     const mode = process.env.TOOL_MODE as ToolMode;
     this.toolMode = (["essential", "read", "write", "all"] as ToolMode[]).includes(mode)
@@ -40,6 +43,7 @@ export class ToolRegistry {
       ...this.dashboardHandlers.getToolSchemas(),
       ...this.cardHandlers.getToolSchemas(),
       ...this.databaseHandlers.getToolSchemas(),
+      ...this.tableHandlers.getToolSchemas(),
       // Add other tool schemas for collections, users, etc.
       ...this.getAdditionalToolSchemas(),
     ] as TaggedTool[];
@@ -84,6 +88,11 @@ export class ToolRegistry {
     // Database tools
     if (this.isDatabaseTool(name)) {
       return await this.databaseHandlers.handleTool(name, args);
+    }
+
+    // Table tools
+    if (this.isTableTool(name)) {
+      return await this.tableHandlers.handleTool(name, args);
     }
 
     // Handle other tools directly
@@ -135,6 +144,14 @@ export class ToolRegistry {
         "get_database_sync_status",
       ].includes(name)
     );
+  }
+
+  private isTableTool(name: string): boolean {
+    return [
+      "list_tables", "get_table", "get_table_metadata", "get_table_fks",
+      "get_field_id", "update_table", "sync_table_schema",
+      "rescan_table_field_values", "discard_table_field_values",
+    ].includes(name);
   }
 
   private getAdditionalToolSchemas(): TaggedTool[] {

--- a/src/handlers/tool-registry.ts
+++ b/src/handlers/tool-registry.ts
@@ -8,35 +8,69 @@ import { CardToolHandlers } from "./card-tools.js";
 import { DatabaseToolHandlers } from "./database-tools.js";
 import { ErrorCode, McpError } from "../types/errors.js";
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { ToolMode, TaggedTool } from "../types/tool-metadata.js";
 
 export class ToolRegistry {
   private dashboardHandlers: DashboardToolHandlers;
   private cardHandlers: CardToolHandlers;
   private databaseHandlers: DatabaseToolHandlers;
+  private toolMode: ToolMode;
+  private visibleToolNames: Set<string> | null = null;
 
   constructor(private client: MetabaseClient) {
     this.dashboardHandlers = new DashboardToolHandlers(client);
     this.cardHandlers = new CardToolHandlers(client);
     this.databaseHandlers = new DatabaseToolHandlers(client);
+
+    const mode = process.env.TOOL_MODE as ToolMode;
+    this.toolMode = (["essential", "read", "write", "all"] as ToolMode[]).includes(mode)
+      ? mode
+      : "all";
+
+    this.visibleToolNames = this.toolMode === "all"
+      ? null  // null means "all allowed"
+      : new Set(this.getAllToolSchemas().map(t => t.name));
   }
 
   /**
-   * Get all available tool schemas
+   * Get all available tool schemas, filtered by TOOL_MODE
    */
   getAllToolSchemas(): Tool[] {
-    return [
+    const all = [
       ...this.dashboardHandlers.getToolSchemas(),
       ...this.cardHandlers.getToolSchemas(),
       ...this.databaseHandlers.getToolSchemas(),
       // Add other tool schemas for collections, users, etc.
       ...this.getAdditionalToolSchemas(),
-    ];
+    ] as TaggedTool[];
+
+    if (this.toolMode === "all") return all;
+
+    return all.filter(tool => {
+      const meta = tool.metadata;
+      if (!meta) {
+        console.error(JSON.stringify({
+          level: "warn",
+          message: `Tool '${tool.name}' has no metadata and will be hidden in TOOL_MODE '${this.toolMode}'`,
+        }));
+        return false;
+      }
+      return meta.mode.includes(this.toolMode);
+    });
   }
 
   /**
    * Handle a tool call
    */
   async handleTool(name: string, args: any): Promise<any> {
+    // Enforce mode filter — reject tools not visible in current mode
+    if (this.visibleToolNames !== null && !this.visibleToolNames.has(name)) {
+      throw new McpError(
+        ErrorCode.MethodNotFound,
+        `Tool not available in TOOL_MODE '${this.toolMode}': ${name}`
+      );
+    }
+
     // Dashboard tools
     if (this.isDashboardTool(name)) {
       return await this.dashboardHandlers.handleTool(name, args);
@@ -95,11 +129,15 @@ export class ToolRegistry {
         "execute_query",
         "get_database_schema",
         "get_database_tables",
+        "create_database_connection",
+        "test_database_connection",
+        "sync_database_schema",
+        "get_database_sync_status",
       ].includes(name)
     );
   }
 
-  private getAdditionalToolSchemas(): Tool[] {
+  private getAdditionalToolSchemas(): TaggedTool[] {
     return [
       // Collection tools
       {
@@ -115,6 +153,7 @@ export class ToolRegistry {
             },
           },
         },
+        metadata: { mode: ["read", "write", "all"], tags: ["collection"] },
       },
       {
         name: "create_collection",
@@ -135,6 +174,7 @@ export class ToolRegistry {
           },
           required: ["name"],
         },
+        metadata: { mode: ["write", "all"], tags: ["collection"] },
       },
       // User tools
       {
@@ -150,6 +190,7 @@ export class ToolRegistry {
             },
           },
         },
+        metadata: { mode: ["read", "write", "all"], tags: ["user"] },
       },
       {
         name: "create_user",
@@ -169,6 +210,7 @@ export class ToolRegistry {
           },
           required: ["first_name", "last_name", "email"],
         },
+        metadata: { mode: ["write", "all"], tags: ["user"] },
       },
       // Permission tools
       {
@@ -178,6 +220,7 @@ export class ToolRegistry {
           type: "object",
           properties: {},
         },
+        metadata: { mode: ["read", "write", "all"], tags: ["permission"] },
       },
       {
         name: "create_permission_group",
@@ -192,6 +235,7 @@ export class ToolRegistry {
           },
           required: ["name"],
         },
+        metadata: { mode: ["write", "all"], tags: ["permission"] },
       },
       // Search tools
       {
@@ -212,6 +256,7 @@ export class ToolRegistry {
           },
           required: ["query"],
         },
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["search"] },
       },
     ];
   }

--- a/src/handlers/tool-registry.ts
+++ b/src/handlers/tool-registry.ts
@@ -526,12 +526,14 @@ export class ToolRegistry {
 
   private async handleGetCollection(args: any): Promise<any> {
     const { collection_id } = args;
+    if (!collection_id) throw new McpError(ErrorCode.InvalidParams, "collection_id is required");
     const result = await this.client.apiCall("GET", `/api/collection/${collection_id}`);
     return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
   }
 
   private async handleUpdateCollection(args: any): Promise<any> {
     const { collection_id, ...updates } = args;
+    if (!collection_id) throw new McpError(ErrorCode.InvalidParams, "collection_id is required");
     const result = await this.client.apiCall("PUT", `/api/collection/${collection_id}`, updates);
     return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
   }
@@ -546,7 +548,7 @@ export class ToolRegistry {
     const { collection_id, models } = args;
     const id = collection_id ?? "root";
     const params: any = {};
-    if (models?.length) params.models = models.join(",");
+    if (models?.length) params.models = models;
     const result = await this.client.apiCall("GET", `/api/collection/${id}/items`, params);
     return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
   }

--- a/src/types/tool-metadata.ts
+++ b/src/types/tool-metadata.ts
@@ -1,0 +1,11 @@
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export type ToolMode = "essential" | "read" | "write" | "all";
+
+export interface ToolMetadata {
+  mode: ToolMode[];    // which modes include this tool
+  tags?: string[];     // optional: "dashboard", "card", "database", etc.
+}
+
+// Extend MCP Tool type with metadata
+export type TaggedTool = Tool & { metadata?: ToolMetadata };


### PR DESCRIPTION
## Summary

Adds TOOL_MODE filtering infrastructure and 33 new tools across 6 domains, bringing the total from 29 to **62 tools**.

---

## Phase 1 — Tool Filtering Infrastructure

New `TOOL_MODE` env var (`essential` | `read` | `write` | `all`, default: `all`)

- Added `ToolMetadata` type and `TaggedTool` (extends MCP `Tool` with `metadata.mode[]`)
- Tagged all 29 existing tools with appropriate modes
- `ToolRegistry.getAllToolSchemas()` filters by mode at startup
- Tools without metadata are hidden in non-`all` modes (with a warning log)
- Updated `.env.example` with documentation

## Phase 2 — Table Tools (9 new tools)

New file: `src/handlers/table-tools.ts`

`list_tables`, `get_table`, `get_table_metadata`, `get_table_fks`, `get_field_id`, `update_table`, `sync_table_schema`, `rescan_table_field_values`, `discard_table_field_values`

## Phase 3 — Public Sharing & Embedding (8 new tools)

`create_card_public_link`, `delete_card_public_link`, `list_public_cards`, `list_embeddable_cards`, `create_dashboard_public_link`, `delete_dashboard_public_link`, `list_public_dashboards`, `list_embeddable_dashboards`

## Phase 4 — Advanced Card Operations (4 new tools)

`export_card_result`, `copy_card`, `get_card_query_metadata`, `get_card_dashboards`

## Phase 5 — Collection CRUD + Dashboard Audit (8 new tools)

`get_collection`, `update_collection`, `delete_collection`, `get_collection_items`, `copy_dashboard`, `get_dashboard_revisions`, `revert_dashboard`, `get_dashboard_related`

## Phase 6 — Database Diagnostics (4 new tools)

`check_database_health`, `validate_database`, `list_database_schemas`, `get_database_metadata`

---

## Tool Count

| Version | Tools |
|---|---|
| v1.0.5 (baseline) | 29 |
| This PR | **62** |

---

## Test Plan

- [ ] `npm run build` passes (verified clean)
- [ ] Set `TOOL_MODE=essential` and confirm only essential tools appear in MCP Inspector
- [ ] Set `TOOL_MODE=read` and confirm no write tools appear
- [ ] Smoke test `list_tables`, `get_table_metadata`, `get_field_id` against a live Metabase instance
- [ ] Smoke test `export_card_result` (csv + json formats)
- [ ] Smoke test `get_collection_items` on root collection
- [ ] Smoke test `copy_dashboard`