### PR TITLE
feat: add 31 missing tools (dashboard, card, database, table)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ export METABASE_API_KEY=your_metabase_api_key
 npx @easecloudio/mcp-metabase-server
 ```
 
-## 64 Tools Available
+## 96 Tools Available
 
 | Domain | Tools |
 |---|---|
-| Dashboard Management | 16 |
-| Card / Question Management | 14 |
-| Database Management | 12 |
-| Table Management | 9 |
-| Collections, Users & Search | 11 |
+| Dashboard Management | 27 |
+| Card / Question Management | 21 |
+| Database Management | 16 |
+| Table Management | 17 |
+| Collections, Users & Search | 13 |
 | Schema Cache (SQL→MBQL) | 2 |
 
 ## Supported Metabase Versions
@@ -175,24 +175,34 @@ Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 ## Available Tools
 
 <details>
-<summary><strong>Dashboard Management (16 tools)</strong></summary>
+<summary><strong>Dashboard Management (27 tools)</strong></summary>
 
 ### Core CRUD
 | Tool | Description |
 |---|---|
 | `list_dashboards` | List all dashboards |
+| `get_dashboard` | Get a specific dashboard by ID |
 | `create_dashboard` | Create a new dashboard |
 | `update_dashboard` | Update an existing dashboard |
 | `delete_dashboard` | Delete / archive a dashboard |
 | `copy_dashboard` | Duplicate a dashboard (shallow or deep copy) |
+| `save_dashboard` | Save a complete dashboard object with nested data |
+| `save_dashboard_to_collection` | Move a dashboard into a specific collection |
+| `search_dashboards` | Search dashboards by name or description |
+| `favorite_dashboard` | Mark a dashboard as a favourite |
+| `unfavorite_dashboard` | Remove a dashboard from favourites |
 
 ### Card Layout
 | Tool | Description |
 |---|---|
 | `get_dashboard_cards` | Get all cards in a dashboard |
 | `add_card_to_dashboard` | Add a card with positioning |
+| `add_text_block` | Add a text or heading block to a dashboard |
 | `remove_card_from_dashboard` | Remove a card |
 | `update_dashboard_card` | Update card position, size, and settings |
+| `update_dashboard_cards` | Bulk-replace all cards on a dashboard |
+| `update_dashcard` | Update a specific dashcard's properties |
+| `execute_dashboard_card` | Execute a specific dashcard and return results |
 
 ### Public Sharing & Embedding
 | Tool | Description |
@@ -202,17 +212,18 @@ Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 | `list_public_dashboards` | List dashboards with public links |
 | `list_embeddable_dashboards` | List dashboards enabled for embedding |
 
-### Revision & Discovery
+### Revision, Audit & Discovery
 | Tool | Description |
 |---|---|
 | `get_dashboard_revisions` | Get revision history (audit trail) |
 | `revert_dashboard` | Revert to a previous revision |
 | `get_dashboard_related` | Get related content suggestions |
+| `get_dashboard_queries` | Extract all card queries with resolved field IDs |
 
 </details>
 
 <details>
-<summary><strong>Card / Question Management (14 tools)</strong></summary>
+<summary><strong>Card / Question Management (21 tools)</strong></summary>
 
 ### Core CRUD
 | Tool | Description |
@@ -223,18 +234,29 @@ Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 | `update_card` | Update an existing question |
 | `delete_card` | Delete / archive a question |
 | `copy_card` | Duplicate a card |
+| `move_cards` | Move one or more cards to a different collection |
+| `move_cards_to_collection` | Bulk-move cards from a source collection |
 
 ### Execution & Export
 | Tool | Description |
 |---|---|
 | `execute_card` | Run a card and return results |
+| `execute_pivot_card_query` | Run a card formatted as a pivot table |
 | `export_card_result` | Export results as CSV or JSON |
+
+### Parameters
+| Tool | Description |
+|---|---|
+| `get_card_param_values` | Get available values for a card parameter |
+| `search_card_param_values` | Search / filter parameter values |
+| `get_card_param_remapping` | Get how parameter values are remapped for display |
 
 ### Metadata & Discovery
 | Tool | Description |
 |---|---|
 | `get_card_query_metadata` | Get column types and display names |
 | `get_card_dashboards` | List dashboards containing this card |
+| `get_card_series` | Get series data or related card suggestions |
 
 ### Public Sharing & Embedding
 | Tool | Description |
@@ -247,14 +269,22 @@ Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 </details>
 
 <details>
-<summary><strong>Database Management (12 tools)</strong></summary>
+<summary><strong>Database Management (16 tools)</strong></summary>
 
-### Core Operations
+### Core CRUD
 | Tool | Description |
 |---|---|
 | `list_databases` | List all database connections |
-| `execute_query` | Execute a SQL query against a database |
+| `get_database` | Get a specific database by ID |
 | `create_database_connection` | Create a new database connection |
+| `update_database` | Update a database connection's config or credentials |
+| `delete_database` | Permanently remove a database connection |
+| `add_sample_database` | Add the built-in H2 sample database with demo data |
+
+### Querying
+| Tool | Description |
+|---|---|
+| `execute_query` | Execute a SQL query against a database |
 
 ### Schema & Sync
 | Tool | Description |
@@ -276,7 +306,7 @@ Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 </details>
 
 <details>
-<summary><strong>Table Management (9 tools)</strong></summary>
+<summary><strong>Table Management (17 tools)</strong></summary>
 
 ### Metadata
 | Tool | Description |
@@ -285,20 +315,36 @@ Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 | `get_table` | Get table metadata by ID |
 | `get_table_metadata` | Get full query metadata including field IDs and types |
 | `get_table_fks` | Get foreign key relationships |
+| `get_table_related` | Find related tables via FK relationships |
+| `get_table_data` | Get a sample data preview from a table |
 | `get_field_id` | Look up a field ID by table ID + column name (returns MBQL ref) |
+
+### Card Virtual Tables
+| Tool | Description |
+|---|---|
+| `get_card_table_fks` | Get FK relationships for a card's virtual table |
+| `get_card_table_query_metadata` | Get query metadata for a card's virtual table |
 
 ### Management
 | Tool | Description |
 |---|---|
 | `update_table` | Update display name, description, or visibility |
+| `update_tables` | Bulk-update multiple tables with the same config |
+| `reorder_table_fields` | Change the display order of fields |
 | `sync_table_schema` | Trigger a schema sync for a specific table |
 | `rescan_table_field_values` | Rescan field values (updates filter dropdowns) |
 | `discard_table_field_values` | Discard cached field values |
 
+### CSV Upload (Metabase-managed tables)
+| Tool | Description |
+|---|---|
+| `append_csv_to_table` | Append new rows from CSV content |
+| `replace_table_csv` | Replace all table data with new CSV content |
+
 </details>
 
 <details>
-<summary><strong>Collections, Users & Search (11 tools)</strong></summary>
+<summary><strong>Collections, Users & Search (13 tools)</strong></summary>
 
 ### Collections
 | Tool | Description |
@@ -309,6 +355,7 @@ Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 | `update_collection` | Update name, description, color, or parent |
 | `delete_collection` | Delete a collection and its contents |
 | `get_collection_items` | List cards, dashboards, and sub-collections |
+| `move_to_collection` | Move a card or dashboard to a different collection |
 
 ### Users
 | Tool | Description |

--- a/src/handlers/card-tools.ts
+++ b/src/handlers/card-tools.ts
@@ -307,6 +307,118 @@ export class CardToolHandlers {
           required: ["card_id"],
         },
       },
+      {
+        name: "move_cards",
+        description: "Move one or more cards to a different collection",
+        metadata: { mode: ["write", "all"], tags: ["card"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            card_ids: {
+              type: "array",
+              items: { type: "number" },
+              description: "IDs of the cards to move",
+            },
+            collection_id: {
+              type: ["number", "null"],
+              description: "ID of the destination collection, or null for root",
+            },
+          },
+          required: ["card_ids", "collection_id"],
+        },
+      },
+      {
+        name: "move_cards_to_collection",
+        description: "Move all cards matching a filter to a specific collection",
+        metadata: { mode: ["write", "all"], tags: ["card"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            collection_id: {
+              type: "number",
+              description: "ID of the destination collection",
+            },
+            source_collection_id: {
+              type: "number",
+              description: "If provided, only move cards from this collection",
+            },
+          },
+          required: ["collection_id"],
+        },
+      },
+      {
+        name: "execute_pivot_card_query",
+        description: "Execute a card query and return results formatted as a pivot table",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["card"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            card_id: { type: "number", description: "ID of the card to execute" },
+            parameters: {
+              type: "array",
+              description: "Optional parameters for the query",
+              items: { type: "object" },
+            },
+          },
+          required: ["card_id"],
+        },
+      },
+      {
+        name: "get_card_param_values",
+        description: "Get available values for a card parameter (for populating filter dropdowns)",
+        metadata: { mode: ["read", "write", "all"], tags: ["card"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            card_id: { type: "number", description: "ID of the card" },
+            param_id: {
+              type: "string",
+              description: "The parameter ID/slug",
+            },
+          },
+          required: ["card_id", "param_id"],
+        },
+      },
+      {
+        name: "search_card_param_values",
+        description: "Search and filter available values for a card parameter",
+        metadata: { mode: ["read", "write", "all"], tags: ["card"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            card_id: { type: "number", description: "ID of the card" },
+            param_id: { type: "string", description: "The parameter ID/slug" },
+            query: { type: "string", description: "Search term to filter values" },
+          },
+          required: ["card_id", "param_id", "query"],
+        },
+      },
+      {
+        name: "get_card_param_remapping",
+        description: "Get how a card parameter's values are remapped for display (e.g. ID to name)",
+        metadata: { mode: ["read", "write", "all"], tags: ["card"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            card_id: { type: "number", description: "ID of the card" },
+            param_id: { type: "string", description: "The parameter ID/slug" },
+            value: { type: "string", description: "The raw value to remap" },
+          },
+          required: ["card_id", "param_id", "value"],
+        },
+      },
+      {
+        name: "get_card_series",
+        description: "Get time series data or related card suggestions for a card",
+        metadata: { mode: ["read", "write", "all"], tags: ["card"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            card_id: { type: "number", description: "ID of the card" },
+          },
+          required: ["card_id"],
+        },
+      },
     ];
   }
 
@@ -346,6 +458,27 @@ export class CardToolHandlers {
         return await this.getCardQueryMetadata(args);
       case "get_card_dashboards":
         return await this.getCardDashboards(args);
+
+      case "move_cards":
+        return await this.moveCards(args);
+
+      case "move_cards_to_collection":
+        return await this.moveCardsToCollection(args);
+
+      case "execute_pivot_card_query":
+        return await this.executePivotCardQuery(args);
+
+      case "get_card_param_values":
+        return await this.getCardParamValues(args);
+
+      case "search_card_param_values":
+        return await this.searchCardParamValues(args);
+
+      case "get_card_param_remapping":
+        return await this.getCardParamRemapping(args);
+
+      case "get_card_series":
+        return await this.getCardSeries(args);
 
       default:
         throw new McpError(
@@ -558,6 +691,80 @@ export class CardToolHandlers {
     const { card_id } = args;
     if (!card_id) throw new McpError(ErrorCode.InvalidParams, "card_id is required");
     const result = await this.client.apiCall("GET", `/api/card/${card_id}/dashboards`);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async moveCards(args: any): Promise<any> {
+    const { card_ids, collection_id } = args;
+    if (!card_ids || !Array.isArray(card_ids) || card_ids.length === 0) {
+      throw new McpError(ErrorCode.InvalidParams, "card_ids is required and must be a non-empty array");
+    }
+    if (collection_id === undefined) {
+      throw new McpError(ErrorCode.InvalidParams, "collection_id is required (use null for root)");
+    }
+    const result = await this.client.apiCall("POST", `/api/card/collections`, { card_ids, collection_id });
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async moveCardsToCollection(args: any): Promise<any> {
+    const { collection_id, source_collection_id } = args;
+    if (!collection_id) {
+      throw new McpError(ErrorCode.InvalidParams, "collection_id is required");
+    }
+    const cards: any[] = await this.client.apiCall("GET", `/api/card?f=all`);
+    const filtered = source_collection_id !== undefined
+      ? cards.filter((c: any) => c.collection_id === source_collection_id)
+      : cards;
+    const card_ids = filtered.map((c: any) => c.id);
+    if (card_ids.length === 0) {
+      return { content: [{ type: "text", text: JSON.stringify({ moved: 0, card_ids: [] }, null, 2) }] };
+    }
+    await this.client.apiCall("POST", `/api/card/collections`, { card_ids, collection_id });
+    return {
+      content: [{
+        type: "text",
+        text: JSON.stringify({ moved: card_ids.length, card_ids }, null, 2),
+      }],
+    };
+  }
+
+  private async executePivotCardQuery(args: any): Promise<any> {
+    const { card_id, parameters = [] } = args;
+    if (!card_id) throw new McpError(ErrorCode.InvalidParams, "card_id is required");
+    const result = await this.client.apiCall("POST", `/api/card/${card_id}/query/pivot`, { parameters });
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async getCardParamValues(args: any): Promise<any> {
+    const { card_id, param_id } = args;
+    if (!card_id) throw new McpError(ErrorCode.InvalidParams, "card_id is required");
+    if (!param_id) throw new McpError(ErrorCode.InvalidParams, "param_id is required");
+    const result = await this.client.apiCall("GET", `/api/card/${card_id}/params/${param_id}/values`);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async searchCardParamValues(args: any): Promise<any> {
+    const { card_id, param_id, query } = args;
+    if (!card_id) throw new McpError(ErrorCode.InvalidParams, "card_id is required");
+    if (!param_id) throw new McpError(ErrorCode.InvalidParams, "param_id is required");
+    if (!query) throw new McpError(ErrorCode.InvalidParams, "query is required");
+    const result = await this.client.apiCall("GET", `/api/card/${card_id}/params/${param_id}/search/${encodeURIComponent(query)}`);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async getCardParamRemapping(args: any): Promise<any> {
+    const { card_id, param_id, value } = args;
+    if (!card_id) throw new McpError(ErrorCode.InvalidParams, "card_id is required");
+    if (!param_id) throw new McpError(ErrorCode.InvalidParams, "param_id is required");
+    if (value === undefined || value === null) throw new McpError(ErrorCode.InvalidParams, "value is required");
+    const result = await this.client.apiCall("GET", `/api/card/${card_id}/params/${param_id}/remapping?value=${encodeURIComponent(value)}`);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async getCardSeries(args: any): Promise<any> {
+    const { card_id } = args;
+    if (!card_id) throw new McpError(ErrorCode.InvalidParams, "card_id is required");
+    const result = await this.client.apiCall("GET", `/api/card/${card_id}/series`);
     return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
   }
 }

--- a/src/handlers/dashboard-tools.ts
+++ b/src/handlers/dashboard-tools.ts
@@ -331,6 +331,182 @@ export class DashboardToolHandlers {
           required: ["dashboard_id"],
         },
       },
+      {
+        name: "get_dashboard",
+        description: "Get a specific dashboard by ID with full details",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["dashboard"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            dashboard_id: { type: "number", description: "ID of the dashboard" },
+          },
+          required: ["dashboard_id"],
+        },
+      },
+      {
+        name: "search_dashboards",
+        description: "Search dashboards by name or description",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["dashboard"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: { type: "string", description: "Search query string" },
+          },
+          required: ["query"],
+        },
+      },
+      {
+        name: "execute_dashboard_card",
+        description: "Execute a specific card on a dashboard and return results",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["dashboard"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            dashboard_id: { type: "number", description: "ID of the dashboard" },
+            dashcard_id: { type: "number", description: "ID of the dashcard" },
+            card_id: { type: "number", description: "ID of the card" },
+            parameters: {
+              type: "array",
+              description: "Optional parameters to pass to the query",
+              items: { type: "object" },
+              default: [],
+            },
+          },
+          required: ["dashboard_id", "dashcard_id", "card_id"],
+        },
+      },
+      {
+        name: "favorite_dashboard",
+        description: "Mark a dashboard as a favourite",
+        metadata: { mode: ["write", "all"], tags: ["dashboard"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            dashboard_id: { type: "number", description: "ID of the dashboard" },
+          },
+          required: ["dashboard_id"],
+        },
+      },
+      {
+        name: "unfavorite_dashboard",
+        description: "Remove a dashboard from favourites",
+        metadata: { mode: ["write", "all"], tags: ["dashboard"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            dashboard_id: { type: "number", description: "ID of the dashboard" },
+          },
+          required: ["dashboard_id"],
+        },
+      },
+      {
+        name: "add_text_block",
+        description: "Add a text or heading block to a dashboard",
+        metadata: { mode: ["write", "all"], tags: ["dashboard"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            dashboard_id: { type: "number", description: "ID of the dashboard" },
+            text: { type: "string", description: "Text content for the block" },
+            visualization_settings: {
+              type: "object",
+              description: "Additional visualization settings (e.g. { \"text.align_horizontal\": \"left\" })",
+            },
+            row: { type: "number", description: "Row position (0-based)", default: 0 },
+            col: { type: "number", description: "Column position (0-based)", default: 0 },
+            size_x: { type: "number", description: "Width in grid units", default: 4 },
+            size_y: { type: "number", description: "Height in grid units", default: 2 },
+          },
+          required: ["dashboard_id", "text"],
+        },
+      },
+      {
+        name: "update_dashcard",
+        description: "Update a specific dashcard's position, size, or settings",
+        metadata: { mode: ["write", "all"], tags: ["dashboard"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            dashboard_id: { type: "number", description: "ID of the dashboard" },
+            dashcard_id: { type: "number", description: "ID of the dashcard to update" },
+            row: { type: "number", description: "New row position" },
+            col: { type: "number", description: "New column position" },
+            size_x: { type: "number", description: "New width in grid units" },
+            size_y: { type: "number", description: "New height in grid units" },
+            visualization_settings: {
+              type: "object",
+              description: "Updated visualization settings",
+            },
+            parameter_mappings: {
+              type: "array",
+              description: "Updated parameter mappings",
+              items: { type: "object" },
+            },
+          },
+          required: ["dashboard_id", "dashcard_id"],
+        },
+      },
+      {
+        name: "update_dashboard_cards",
+        description: "Bulk-replace all cards on a dashboard. WARNING: replaces the entire card layout.",
+        metadata: { mode: ["write", "all"], tags: ["dashboard"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            dashboard_id: { type: "number", description: "ID of the dashboard" },
+            cards: {
+              type: "array",
+              description: "Array of dashcard objects to replace the current layout",
+              items: { type: "object" },
+            },
+          },
+          required: ["dashboard_id", "cards"],
+        },
+      },
+      {
+        name: "save_dashboard",
+        description: "Save a complete dashboard object including nested cards and settings",
+        metadata: { mode: ["write", "all"], tags: ["dashboard"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            dashboard_id: { type: "number", description: "ID of the dashboard to save" },
+            dashboard: {
+              type: "object",
+              description: "The full dashboard object to save",
+            },
+          },
+          required: ["dashboard_id", "dashboard"],
+        },
+      },
+      {
+        name: "save_dashboard_to_collection",
+        description: "Move a dashboard into a specific collection",
+        metadata: { mode: ["write", "all"], tags: ["dashboard"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            dashboard_id: { type: "number", description: "ID of the dashboard" },
+            collection_id: {
+              type: ["number", "null"],
+              description: "ID of the target collection, or null for root collection",
+            },
+          },
+          required: ["dashboard_id", "collection_id"],
+        },
+      },
+      {
+        name: "get_dashboard_queries",
+        description: "Extract all card queries from a dashboard with their resolved database IDs and SQL. Useful for auditing what data a dashboard queries.",
+        metadata: { mode: ["read", "write", "all"], tags: ["dashboard"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            dashboard_id: { type: "number", description: "ID of the dashboard" },
+          },
+          required: ["dashboard_id"],
+        },
+      },
     ];
   }
 
@@ -408,6 +584,39 @@ export class DashboardToolHandlers {
         return await this.revertDashboard(args);
       case "get_dashboard_related":
         return await this.getDashboardRelated(args);
+
+      case "get_dashboard":
+        return await this.getDashboard(args);
+
+      case "search_dashboards":
+        return await this.searchDashboards(args);
+
+      case "execute_dashboard_card":
+        return await this.executeDashboardCard(args);
+
+      case "favorite_dashboard":
+        return await this.favoriteDashboard(args);
+
+      case "unfavorite_dashboard":
+        return await this.unfavoriteDashboard(args);
+
+      case "add_text_block":
+        return await this.addTextBlock(args);
+
+      case "update_dashcard":
+        return await this.updateDashcard(args);
+
+      case "update_dashboard_cards":
+        return await this.updateDashboardCards(args);
+
+      case "save_dashboard":
+        return await this.saveDashboard(args);
+
+      case "save_dashboard_to_collection":
+        return await this.saveDashboardToCollection(args);
+
+      case "get_dashboard_queries":
+        return await this.getDashboardQueries(args);
 
       default:
         throw new McpError(
@@ -819,5 +1028,157 @@ export class DashboardToolHandlers {
     if (!dashboard_id) throw new McpError(ErrorCode.InvalidParams, "dashboard_id is required");
     const result = await this.client.apiCall("GET", `/api/dashboard/${dashboard_id}/related`);
     return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async getDashboard(args: any): Promise<any> {
+    const { dashboard_id } = args;
+    if (!dashboard_id) throw new McpError(ErrorCode.InvalidParams, "dashboard_id is required");
+    const result = await this.client.apiCall("GET", `/api/dashboard/${dashboard_id}`);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async searchDashboards(args: any): Promise<any> {
+    const { query } = args;
+    if (!query) throw new McpError(ErrorCode.InvalidParams, "query is required");
+    const result = await this.client.apiCall("GET", `/api/search?q=${encodeURIComponent(query)}&models=dashboard`);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async executeDashboardCard(args: any): Promise<any> {
+    const { dashboard_id, dashcard_id, card_id, parameters = [] } = args;
+    if (!dashboard_id) throw new McpError(ErrorCode.InvalidParams, "dashboard_id is required");
+    if (!dashcard_id) throw new McpError(ErrorCode.InvalidParams, "dashcard_id is required");
+    if (!card_id) throw new McpError(ErrorCode.InvalidParams, "card_id is required");
+    const result = await this.client.apiCall(
+      "POST",
+      `/api/dashboard/${dashboard_id}/dashcard/${dashcard_id}/card/${card_id}/query`,
+      { parameters }
+    );
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async favoriteDashboard(args: any): Promise<any> {
+    const { dashboard_id } = args;
+    if (!dashboard_id) throw new McpError(ErrorCode.InvalidParams, "dashboard_id is required");
+    const result = await this.client.apiCall("POST", `/api/dashboard/${dashboard_id}/favorite`);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async unfavoriteDashboard(args: any): Promise<any> {
+    const { dashboard_id } = args;
+    if (!dashboard_id) throw new McpError(ErrorCode.InvalidParams, "dashboard_id is required");
+    await this.client.apiCall("DELETE", `/api/dashboard/${dashboard_id}/favorite`);
+    return { content: [{ type: "text", text: `Dashboard ${dashboard_id} removed from favourites.` }] };
+  }
+
+  private async addTextBlock(args: any): Promise<any> {
+    const {
+      dashboard_id,
+      text,
+      visualization_settings = {},
+      row = 0,
+      col = 0,
+      size_x = 4,
+      size_y = 2,
+    } = args;
+    if (!dashboard_id) throw new McpError(ErrorCode.InvalidParams, "dashboard_id is required");
+    if (!text) throw new McpError(ErrorCode.InvalidParams, "text is required");
+
+    const body = {
+      cardId: null,
+      row,
+      col,
+      size_x,
+      size_y,
+      series: [],
+      visualization_settings: {
+        virtual_card: {
+          name: null,
+          display: "text",
+          dataset_query: {},
+          visualization_settings: {},
+        },
+        text,
+        ...visualization_settings,
+      },
+    };
+
+    const result = await this.client.apiCall("POST", `/api/dashboard/${dashboard_id}/cards`, body);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async updateDashcard(args: any): Promise<any> {
+    const { dashboard_id, dashcard_id, ...updateFields } = args;
+    if (!dashboard_id) throw new McpError(ErrorCode.InvalidParams, "dashboard_id is required");
+    if (!dashcard_id) throw new McpError(ErrorCode.InvalidParams, "dashcard_id is required");
+
+    const dashboard = await this.client.getDashboard(dashboard_id);
+    const updatedCards = (dashboard.dashcards || []).map((card: any) =>
+      card.id === dashcard_id
+        ? this.toDashcardPayload(card, updateFields)
+        : this.toDashcardPayload(card)
+    );
+
+    const result = await this.client.apiCall(
+      "PUT",
+      `/api/dashboard/${dashboard_id}/cards`,
+      { cards: updatedCards, tabs: dashboard.tabs || [] }
+    );
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async updateDashboardCards(args: any): Promise<any> {
+    const { dashboard_id, cards } = args;
+    if (!dashboard_id) throw new McpError(ErrorCode.InvalidParams, "dashboard_id is required");
+    if (!cards) throw new McpError(ErrorCode.InvalidParams, "cards is required");
+
+    const result = await this.client.apiCall(
+      "PUT",
+      `/api/dashboard/${dashboard_id}/cards`,
+      { cards }
+    );
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async saveDashboard(args: any): Promise<any> {
+    const { dashboard_id, dashboard } = args;
+    if (!dashboard_id) throw new McpError(ErrorCode.InvalidParams, "dashboard_id is required");
+    if (!dashboard) throw new McpError(ErrorCode.InvalidParams, "dashboard is required");
+
+    const result = await this.client.apiCall("PUT", `/api/dashboard/${dashboard_id}`, dashboard);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async saveDashboardToCollection(args: any): Promise<any> {
+    const { dashboard_id, collection_id } = args;
+    if (!dashboard_id) throw new McpError(ErrorCode.InvalidParams, "dashboard_id is required");
+    if (collection_id === undefined) throw new McpError(ErrorCode.InvalidParams, "collection_id is required");
+
+    const result = await this.client.apiCall(
+      "PUT",
+      `/api/dashboard/${dashboard_id}`,
+      { collection_id }
+    );
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async getDashboardQueries(args: any): Promise<any> {
+    const { dashboard_id } = args;
+    if (!dashboard_id) throw new McpError(ErrorCode.InvalidParams, "dashboard_id is required");
+
+    const dashboard = await this.client.apiCall("GET", `/api/dashboard/${dashboard_id}`);
+    const allCards = dashboard.ordered_cards || dashboard.dashcards || [];
+
+    const queries = allCards
+      .filter((dc: any) => dc.card != null)
+      .map((dc: any) => ({
+        dashcard_id: dc.id,
+        card_id: dc.card.id,
+        card_name: dc.card.name,
+        display: dc.card.display,
+        dataset_query: dc.card.dataset_query,
+      }));
+
+    return { content: [{ type: "text", text: JSON.stringify(queries, null, 2) }] };
   }
 }

--- a/src/handlers/database-tools.ts
+++ b/src/handlers/database-tools.ts
@@ -193,6 +193,57 @@ export class DatabaseToolHandlers {
           required: ["database_id"],
         },
       },
+      {
+        name: "get_database",
+        description: "Get detailed information about a specific database connection",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["database"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            database_id: { type: "number", description: "ID of the database" },
+          },
+          required: ["database_id"],
+        },
+      },
+      {
+        name: "update_database",
+        description: "Update a database connection's configuration, credentials, or sync settings",
+        metadata: { mode: ["write", "all"], tags: ["database"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            database_id: { type: "number", description: "ID of the database to update" },
+            name: { type: "string", description: "New name for the database connection" },
+            engine: { type: "string", description: "Database engine (e.g., 'postgres', 'mysql')" },
+            details: { type: "object", description: "Connection details to update" },
+            schedules: { type: "object", description: "Sync schedules configuration" },
+            auto_run_queries: { type: "boolean", description: "Whether to auto-run queries" },
+            refingerprint: { type: "boolean", description: "Whether to re-fingerprint the database" },
+          },
+          required: ["database_id"],
+        },
+      },
+      {
+        name: "delete_database",
+        description: "Permanently remove a database connection from Metabase",
+        metadata: { mode: ["write", "all"], tags: ["database"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            database_id: { type: "number", description: "ID of the database to delete" },
+          },
+          required: ["database_id"],
+        },
+      },
+      {
+        name: "add_sample_database",
+        description: "Add the built-in Metabase sample database (H2) with demo data for testing",
+        metadata: { mode: ["write", "all"], tags: ["database"] },
+        inputSchema: {
+          type: "object",
+          properties: {},
+        },
+      },
     ];
   }
 
@@ -230,6 +281,18 @@ export class DatabaseToolHandlers {
         return await this.listDatabaseSchemas(args);
       case "get_database_metadata":
         return await this.getDatabaseMetadataTool(args);
+
+      case "get_database":
+        return await this.getDatabase(args);
+
+      case "update_database":
+        return await this.updateDatabase(args);
+
+      case "delete_database":
+        return await this.deleteDatabase(args);
+
+      case "add_sample_database":
+        return await this.addSampleDatabase();
 
       default:
         throw new McpError(
@@ -463,5 +526,38 @@ export class DatabaseToolHandlers {
     if (!database_id) throw new McpError(ErrorCode.InvalidParams, "database_id is required");
     const metadata = await this.client.apiCall("GET", `/api/database/${database_id}/metadata`);
     return { content: [{ type: "text", text: JSON.stringify(metadata, null, 2) }] };
+  }
+
+  private async getDatabase(args: any): Promise<any> {
+    const { database_id } = args;
+    if (!database_id) throw new McpError(ErrorCode.InvalidParams, "database_id is required");
+    const database = await this.client.apiCall("GET", `/api/database/${database_id}`);
+    return { content: [{ type: "text", text: JSON.stringify(database, null, 2) }] };
+  }
+
+  private async updateDatabase(args: any): Promise<any> {
+    const { database_id, name, engine, details, schedules, auto_run_queries, refingerprint } = args;
+    if (!database_id) throw new McpError(ErrorCode.InvalidParams, "database_id is required");
+    const body: Record<string, any> = {};
+    if (name !== undefined) body.name = name;
+    if (engine !== undefined) body.engine = engine;
+    if (details !== undefined) body.details = details;
+    if (schedules !== undefined) body.schedules = schedules;
+    if (auto_run_queries !== undefined) body.auto_run_queries = auto_run_queries;
+    if (refingerprint !== undefined) body.refingerprint = refingerprint;
+    const result = await this.client.apiCall("PUT", `/api/database/${database_id}`, body);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async deleteDatabase(args: any): Promise<any> {
+    const { database_id } = args;
+    if (!database_id) throw new McpError(ErrorCode.InvalidParams, "database_id is required");
+    await this.client.apiCall("DELETE", `/api/database/${database_id}`);
+    return { content: [{ type: "text", text: JSON.stringify({ message: `Database ${database_id} deleted successfully` }, null, 2) }] };
+  }
+
+  private async addSampleDatabase(): Promise<any> {
+    const result = await this.client.apiCall("POST", "/api/database/sample_database");
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
   }
 }

--- a/src/handlers/table-tools.ts
+++ b/src/handlers/table-tools.ts
@@ -131,6 +131,125 @@ export class TableToolHandlers {
           required: ["table_id"],
         },
       },
+      {
+        name: "update_tables",
+        description: "Bulk-update multiple tables with the same configuration (e.g. hide all at once)",
+        metadata: { mode: ["write", "all"], tags: ["table"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            table_ids: {
+              type: "array",
+              items: { type: "number" },
+              description: "List of table IDs to update",
+            },
+            display_name: { type: "string", description: "New display name for all specified tables" },
+            description: { type: "string", description: "Description for all specified tables" },
+            visibility_type: {
+              type: "string",
+              enum: ["normal", "hidden", "technical", "cruft"],
+              description: "Visibility type for all specified tables",
+            },
+          },
+          required: ["table_ids"],
+        },
+      },
+      {
+        name: "get_table_related",
+        description: "Find tables and entities related to this table through foreign key relationships",
+        metadata: { mode: ["read", "write", "all"], tags: ["table"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            table_id: { type: "number", description: "ID of the table" },
+          },
+          required: ["table_id"],
+        },
+      },
+      {
+        name: "get_card_table_fks",
+        description: "Get foreign key relationships for a card's virtual table",
+        metadata: { mode: ["read", "write", "all"], tags: ["table"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            card_id: { type: "number", description: "ID of the card (question)" },
+          },
+          required: ["card_id"],
+        },
+      },
+      {
+        name: "get_card_table_query_metadata",
+        description: "Get query metadata (fields, types) for a card's virtual table",
+        metadata: { mode: ["read", "write", "all"], tags: ["table"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            card_id: { type: "number", description: "ID of the card (question)" },
+          },
+          required: ["card_id"],
+        },
+      },
+      {
+        name: "get_table_data",
+        description: "Get a sample data preview from a table",
+        metadata: { mode: ["essential", "read", "write", "all"], tags: ["table"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            table_id: { type: "number", description: "ID of the table" },
+            limit: {
+              type: "number",
+              description: "Max rows to return (default: 10)",
+              default: 10,
+            },
+          },
+          required: ["table_id"],
+        },
+      },
+      {
+        name: "append_csv_to_table",
+        description: "Append new rows to a table from CSV content (for Metabase-managed tables)",
+        metadata: { mode: ["write", "all"], tags: ["table"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            table_id: { type: "number", description: "ID of the table" },
+            csv_content: { type: "string", description: "Raw CSV text to append" },
+          },
+          required: ["table_id", "csv_content"],
+        },
+      },
+      {
+        name: "replace_table_csv",
+        description: "Replace all data in a table with new CSV content (for Metabase-managed tables)",
+        metadata: { mode: ["write", "all"], tags: ["table"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            table_id: { type: "number", description: "ID of the table" },
+            csv_content: { type: "string", description: "Raw CSV text to replace table data with" },
+          },
+          required: ["table_id", "csv_content"],
+        },
+      },
+      {
+        name: "reorder_table_fields",
+        description: "Change the display order of fields in a table",
+        metadata: { mode: ["write", "all"], tags: ["table"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            table_id: { type: "number", description: "ID of the table" },
+            field_order: {
+              type: "array",
+              items: { type: "number" },
+              description: "Ordered list of field IDs representing the desired display order",
+            },
+          },
+          required: ["table_id", "field_order"],
+        },
+      },
     ];
   }
 
@@ -145,6 +264,14 @@ export class TableToolHandlers {
       case "sync_table_schema": return await this.syncTableSchema(args);
       case "rescan_table_field_values": return await this.rescanTableFieldValues(args);
       case "discard_table_field_values": return await this.discardTableFieldValues(args);
+      case "update_tables":              return await this.updateTables(args);
+      case "get_table_related":          return await this.getTableRelated(args);
+      case "get_card_table_fks":         return await this.getCardTableFks(args);
+      case "get_card_table_query_metadata": return await this.getCardTableQueryMetadata(args);
+      case "get_table_data":             return await this.getTableData(args);
+      case "append_csv_to_table":        return await this.appendCsvToTable(args);
+      case "replace_table_csv":          return await this.replaceTableCsv(args);
+      case "reorder_table_fields":       return await this.reorderTableFields(args);
       default:
         throw new McpError(ErrorCode.MethodNotFound, `Unknown table tool: ${name}`);
     }
@@ -244,5 +371,79 @@ export class TableToolHandlers {
     if (!table_id) throw new McpError(ErrorCode.InvalidParams, "table_id is required");
     await this.client.apiCall("POST", `/api/table/${table_id}/discard_values`);
     return { content: [{ type: "text", text: `Table ${table_id} field values discarded.` }] };
+  }
+
+  private async updateTables(args: any): Promise<any> {
+    const { table_ids, display_name, description, visibility_type } = args;
+    if (!table_ids || !Array.isArray(table_ids) || table_ids.length === 0) {
+      throw new McpError(ErrorCode.InvalidParams, "table_ids is required and must be a non-empty array");
+    }
+    const updates: Record<string, any> = { ids: table_ids };
+    if (display_name !== undefined) updates.display_name = display_name;
+    if (description !== undefined) updates.description = description;
+    if (visibility_type !== undefined) updates.visibility_type = visibility_type;
+    const result = await this.client.apiCall("PUT", `/api/table`, updates);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async getTableRelated(args: any): Promise<any> {
+    const { table_id } = args;
+    if (!table_id) throw new McpError(ErrorCode.InvalidParams, "table_id is required");
+    const result = await this.client.apiCall("GET", `/api/table/${table_id}/related`);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async getCardTableFks(args: any): Promise<any> {
+    const { card_id } = args;
+    if (!card_id) throw new McpError(ErrorCode.InvalidParams, "card_id is required");
+    const result = await this.client.apiCall("GET", `/api/table/card__${card_id}/fks`);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async getCardTableQueryMetadata(args: any): Promise<any> {
+    const { card_id } = args;
+    if (!card_id) throw new McpError(ErrorCode.InvalidParams, "card_id is required");
+    const result = await this.client.apiCall("GET", `/api/table/card__${card_id}/query_metadata`);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async getTableData(args: any): Promise<any> {
+    const { table_id, limit = 10 } = args;
+    if (!table_id) throw new McpError(ErrorCode.InvalidParams, "table_id is required");
+    // Fetch table info first to get the database ID
+    const tableInfo = await this.client.apiCall("GET", `/api/table/${table_id}`);
+    const db_id = tableInfo.db_id;
+    const result = await this.client.apiCall("POST", `/api/dataset`, {
+      type: "query",
+      database: db_id,
+      query: { "source-table": table_id, limit },
+    });
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async appendCsvToTable(args: any): Promise<any> {
+    const { table_id, csv_content } = args;
+    if (!table_id) throw new McpError(ErrorCode.InvalidParams, "table_id is required");
+    if (!csv_content) throw new McpError(ErrorCode.InvalidParams, "csv_content is required");
+    const result = await this.client.apiCall("POST", `/api/table/${table_id}/append`, { csv: csv_content });
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async replaceTableCsv(args: any): Promise<any> {
+    const { table_id, csv_content } = args;
+    if (!table_id) throw new McpError(ErrorCode.InvalidParams, "table_id is required");
+    if (!csv_content) throw new McpError(ErrorCode.InvalidParams, "csv_content is required");
+    const result = await this.client.apiCall("POST", `/api/table/${table_id}/replace`, { csv: csv_content });
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async reorderTableFields(args: any): Promise<any> {
+    const { table_id, field_order } = args;
+    if (!table_id) throw new McpError(ErrorCode.InvalidParams, "table_id is required");
+    if (!field_order || !Array.isArray(field_order) || field_order.length === 0) {
+      throw new McpError(ErrorCode.InvalidParams, "field_order is required and must be a non-empty array");
+    }
+    const result = await this.client.apiCall("PUT", `/api/table/${table_id}/fields/order`, field_order);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
   }
 }

--- a/src/handlers/tool-registry.ts
+++ b/src/handlers/tool-registry.ts
@@ -113,18 +113,29 @@ export class ToolRegistry {
       name.startsWith("dashboard") ||
       [
         "list_dashboards",
+        "get_dashboard",
         "create_dashboard",
         "update_dashboard",
         "delete_dashboard",
+        "copy_dashboard",
+        "save_dashboard",
+        "save_dashboard_to_collection",
         "get_dashboard_cards",
         "add_card_to_dashboard",
         "remove_card_from_dashboard",
         "update_dashboard_card",
+        "update_dashboard_cards",
+        "update_dashcard",
+        "add_text_block",
+        "execute_dashboard_card",
+        "search_dashboards",
+        "favorite_dashboard",
+        "unfavorite_dashboard",
+        "get_dashboard_queries",
         "create_dashboard_public_link",
         "delete_dashboard_public_link",
         "list_public_dashboards",
         "list_embeddable_dashboards",
-        "copy_dashboard",
         "get_dashboard_revisions",
         "revert_dashboard",
         "get_dashboard_related",
@@ -142,14 +153,21 @@ export class ToolRegistry {
         "update_card",
         "delete_card",
         "execute_card",
+        "execute_pivot_card_query",
+        "copy_card",
+        "move_cards",
+        "move_cards_to_collection",
+        "export_card_result",
         "create_card_public_link",
         "delete_card_public_link",
         "list_public_cards",
         "list_embeddable_cards",
-        "export_card_result",
-        "copy_card",
         "get_card_query_metadata",
         "get_card_dashboards",
+        "get_card_param_values",
+        "search_card_param_values",
+        "get_card_param_remapping",
+        "get_card_series",
       ].includes(name)
     );
   }
@@ -157,20 +175,23 @@ export class ToolRegistry {
   private isDatabaseTool(name: string): boolean {
     return (
       name.startsWith("database") ||
-      name.includes("query") ||
       [
         "list_databases",
+        "get_database",
+        "update_database",
+        "delete_database",
+        "add_sample_database",
         "execute_query",
         "get_database_schema",
         "get_database_tables",
+        "get_database_metadata",
+        "list_database_schemas",
         "create_database_connection",
         "test_database_connection",
+        "validate_database",
         "sync_database_schema",
         "get_database_sync_status",
         "check_database_health",
-        "validate_database",
-        "list_database_schemas",
-        "get_database_metadata",
       ].includes(name)
     );
   }
@@ -178,8 +199,10 @@ export class ToolRegistry {
   private isTableTool(name: string): boolean {
     return [
       "list_tables", "get_table", "get_table_metadata", "get_table_fks",
-      "get_field_id", "update_table", "sync_table_schema",
-      "rescan_table_field_values", "discard_table_field_values",
+      "get_table_related", "get_table_data", "update_table", "update_tables",
+      "sync_table_schema", "rescan_table_field_values", "discard_table_field_values",
+      "reorder_table_fields", "append_csv_to_table", "replace_table_csv",
+      "get_field_id", "get_card_table_fks", "get_card_table_query_metadata",
     ].includes(name);
   }
 
@@ -346,6 +369,21 @@ export class ToolRegistry {
         },
         metadata: { mode: ["write", "all"], tags: ["permission"] },
       },
+      // Move items
+      {
+        name: "move_to_collection",
+        description: "Move a card or dashboard to a different collection",
+        metadata: { mode: ["write", "all"], tags: ["collection"] },
+        inputSchema: {
+          type: "object",
+          properties: {
+            model: { type: "string", enum: ["card", "dashboard"], description: "Type of item to move" },
+            id: { type: "number", description: "ID of the card or dashboard" },
+            collection_id: { type: ["number", "null"], description: "Destination collection ID (null for root)" },
+          },
+          required: ["model", "id", "collection_id"],
+        },
+      },
       // Search tools
       {
         name: "search_content",
@@ -401,6 +439,10 @@ export class ToolRegistry {
       // Search operations
       case "search_content":
         return await this.handleSearchContent(args);
+
+      // Move items
+      case "move_to_collection":
+        return await this.handleMoveToCollection(args);
 
       default:
         throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${name}`);
@@ -563,6 +605,14 @@ export class ToolRegistry {
     const params: any = {};
     if (models?.length) params.models = models;
     const result = await this.client.apiCall("GET", `/api/collection/${id}/items`, params);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+
+  private async handleMoveToCollection(args: any): Promise<any> {
+    const { model, id, collection_id } = args;
+    if (!model || id === undefined) throw new McpError(ErrorCode.InvalidParams, "model and id are required");
+    const endpoint = model === "card" ? `/api/card/${id}` : `/api/dashboard/${id}`;
+    const result = await this.client.apiCall("PUT", endpoint, { collection_id });
     return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
   }
 }


### PR DESCRIPTION
## Summary

Adds 31 new tools across all major domains, bringing the total from 64 to 96 tools.

## New Tools

### Dashboard (11)
- `get_dashboard` — get a single dashboard by ID
- `search_dashboards` — search by name/description
- `execute_dashboard_card` — run a specific dashcard
- `favorite_dashboard` / `unfavorite_dashboard` — favourites
- `add_text_block` — add text/heading blocks
- `update_dashcard` — update a specific dashcard's position/settings
- `update_dashboard_cards` — bulk-replace all cards on a dashboard
- `save_dashboard` — save full dashboard object with nested data
- `save_dashboard_to_collection` — move dashboard to a collection
- `get_dashboard_queries` — extract all queries with resolved field IDs

### Card (7)
- `move_cards` — move one or more cards to a collection
- `move_cards_to_collection` — bulk-move cards by source collection
- `execute_pivot_card_query` — pivot table execution
- `get_card_param_values` — get parameter filter values
- `search_card_param_values` — search parameter values
- `get_card_param_remapping` — get value display remapping
- `get_card_series` — get series data / related suggestions

### Database (4)
- `get_database` — get a single database by ID
- `update_database` — update config and credentials
- `delete_database` — remove a database connection
- `add_sample_database` — add the built-in H2 sample database

### Table (8)
- `update_tables` — bulk-update multiple tables
- `get_table_related` — find related tables via FK relationships
- `get_card_table_fks` — FK relationships for card virtual tables
- `get_card_table_query_metadata` — query metadata for card virtual tables
- `get_table_data` — sample data preview
- `append_csv_to_table` — append CSV rows to a managed table
- `replace_table_csv` — replace table data with CSV
- `reorder_table_fields` — change field display order

### Collections (1)
- `move_to_collection` — move a card or dashboard to a different collection

## Test plan
- [ ] `npm run build` passes (verified clean)
- [ ] `get_dashboard` returns dashboard for a known ID
- [ ] `execute_dashboard_card` returns query results
- [ ] `move_cards` moves a card to a different collection
- [ ] `get_database` returns database details
- [ ] `get_table_data` returns sample rows
- [ ] `move_to_collection` moves a dashboard to a collection